### PR TITLE
fix: replace panicking todo!() in TrId parsing with FromStr returning Error

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -475,37 +475,39 @@ impl Into<String> for TrId {
     }
 }
 
-impl From<&str> for TrId {
-    fn from(s: &str) -> Self {
+impl std::str::FromStr for TrId {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             // Order
-            "TTTC0012U" => TrId::RealStockCashBidOrder,
-            "TTTC0011U" => TrId::RealStockCashAskOrder,
-            "TTTC0052U" => TrId::RealStockCreditBidOrder,
-            "TTTC0051U" => TrId::RealStockCreditAskOrder,
-            "VTTC0012U" => TrId::VirtualStockCashBidOrder,
-            "VTTC0011U" => TrId::VirtualStockCashAskOrder,
+            "TTTC0012U" => Ok(TrId::RealStockCashBidOrder),
+            "TTTC0011U" => Ok(TrId::RealStockCashAskOrder),
+            "TTTC0052U" => Ok(TrId::RealStockCreditBidOrder),
+            "TTTC0051U" => Ok(TrId::RealStockCreditAskOrder),
+            "VTTC0012U" => Ok(TrId::VirtualStockCashBidOrder),
+            "VTTC0011U" => Ok(TrId::VirtualStockCashAskOrder),
             // Correction
-            "TTTC0013U" => TrId::RealStockCorrection,
-            "VTTC0013U" => TrId::VirtualStockCorrection,
+            "TTTC0013U" => Ok(TrId::RealStockCorrection),
+            "VTTC0013U" => Ok(TrId::VirtualStockCorrection),
             // Quote
-            "FHKST01010400" => TrId::DailyPrice,
-            "FHPST01710000" => TrId::VolumeRank,
-            "HHKCM113004C7" => TrId::InstockGrouplist,
-            "HHKCM113004C6" => TrId::InstockGroupItem,
-            "CTPF1002R" => TrId::BasicStockInfo,
+            "FHKST01010400" => Ok(TrId::DailyPrice),
+            "FHPST01710000" => Ok(TrId::VolumeRank),
+            "HHKCM113004C7" => Ok(TrId::InstockGrouplist),
+            "HHKCM113004C6" => Ok(TrId::InstockGroupItem),
+            "CTPF1002R" => Ok(TrId::BasicStockInfo),
             // Market data
-            "H0STCNT0" => TrId::RealtimeExecKrx,
-            "H0STASP0" => TrId::RealtimeOrdbKrx,
-            "H0NXCNT0" => TrId::RealtimeExecNxt,
-            "H0NXASP0" => TrId::RealtimeOrdbNxt,
-            "H0UNCNT0" => TrId::RealtimeExecUnion,
-            "H0UNASP0" => TrId::RealtimeOrdbUnion,
-            "H0STCNI0" => TrId::RealRealtimeMyExec,
-            "H0STCNI9" => TrId::VirtualRealtimeMyExec,
+            "H0STCNT0" => Ok(TrId::RealtimeExecKrx),
+            "H0STASP0" => Ok(TrId::RealtimeOrdbKrx),
+            "H0NXCNT0" => Ok(TrId::RealtimeExecNxt),
+            "H0NXASP0" => Ok(TrId::RealtimeOrdbNxt),
+            "H0UNCNT0" => Ok(TrId::RealtimeExecUnion),
+            "H0UNASP0" => Ok(TrId::RealtimeOrdbUnion),
+            "H0STCNI0" => Ok(TrId::RealRealtimeMyExec),
+            "H0STCNI9" => Ok(TrId::VirtualRealtimeMyExec),
             // PingPong
-            "PINGPONG" => TrId::PingPong,
-            _ => todo!(),
+            "PINGPONG" => Ok(TrId::PingPong),
+            _ => Err(Error::BrokenProtocol("TrId", s.to_string())),
         }
     }
 }

--- a/src/types/stream/stock/exec.rs
+++ b/src/types/stream/stock/exec.rs
@@ -18,7 +18,7 @@ impl StreamParser<Body> for Exec {
     fn parse(s: String) -> Result<Self, Error> {
         if let Ok(j) = json::parse(&s) {
             let header = Header {
-                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().unwrap().into(),
+                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().ok_or(crate::Error::InvalidData)?.parse()?,
                 datetime: Time::parse(
                     get_json_inner(&j, "header.datetime")?.as_str().unwrap(),
                     "%Y%m%d%H%M%S",
@@ -35,7 +35,7 @@ impl StreamParser<Body> for Exec {
                 "%Y%m%d%H%M%S",
             )?;
             let header = Header {
-                tr_id: header_str[1].into(),
+                tr_id: header_str[1].parse()?,
                 datetime: exec_time.clone(),
             };
             let body = if encrypted {

--- a/src/types/stream/stock/my_exec.rs
+++ b/src/types/stream/stock/my_exec.rs
@@ -17,7 +17,7 @@ impl MyExec {
     pub fn parse(s: String, iv: String, key: String) -> Result<Self, Error> {
         if let Ok(j) = json::parse(&s) {
             let header = Header {
-                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().unwrap().into(),
+                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().ok_or(crate::Error::InvalidData)?.parse()?,
                 datetime: Time::parse(
                     get_json_inner(&j, "header.datetime")?.as_str().unwrap(),
                     "%Y%m%d%H%M%S",
@@ -58,7 +58,7 @@ impl MyExec {
             let business_operation_date = Time::now().date();
             let exec_time = Time::parse(&(business_operation_date + splits[11]), "%Y%m%d%H%M%S")?;
             let header = Header {
-                tr_id: header_str[1].into(),
+                tr_id: header_str[1].parse()?,
                 datetime: exec_time.clone(),
             };
             let body = Some(Body {

--- a/src/types/stream/stock/ordb.rs
+++ b/src/types/stream/stock/ordb.rs
@@ -15,7 +15,7 @@ impl StreamParser<Body> for Ordb {
     fn parse(s: String) -> Result<Self, Error> {
         if let Ok(j) = json::parse(&s) {
             let header = Header {
-                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().unwrap().into(),
+                tr_id: get_json_inner(&j, "header.tr_id")?.as_str().ok_or(crate::Error::InvalidData)?.parse()?,
                 datetime: Time::parse(
                     get_json_inner(&j, "header.datetime")?.as_str().unwrap(),
                     "%Y%m%d%H%M%S",
@@ -32,7 +32,7 @@ impl StreamParser<Body> for Ordb {
             let encrypted = header_str[0] == "1";
             let time = Time::parse(&(business_operation_date + splits[1]), "%Y%m%d%H%M%S")?;
             let header = Header {
-                tr_id: header_str[1].into(),
+                tr_id: header_str[1].parse()?,
                 datetime: time.clone(),
             };
             let body = if encrypted {


### PR DESCRIPTION
## Problem

`TrId` implemented `From<&str>` with a `todo!()` fallback, which causes a **runtime panic** when the server sends an unrecognized `tr_id` string. This can happen if the KIS API adds new transaction types or sends unexpected values.

## Solution

Replace `From<&str>` with `std::str::FromStr`, returning `Error::BrokenProtocol` for unrecognized values instead of panicking.

Update the three stream parser call sites (`exec.rs`, `ordb.rs`, `my_exec.rs`) to use `.parse()?` accordingly.

## Changes

- `src/types/mod.rs`: `From<&str> for TrId` → `std::str::FromStr for TrId`
- `src/types/stream/stock/exec.rs`: `.unwrap().into()` → `.ok_or(...)?.parse()?`
- `src/types/stream/stock/ordb.rs`: same
- `src/types/stream/stock/my_exec.rs`: same