### PR TITLE
feat: implement 주식잔고조회 API [v1_국내주식-006]

### DIFF
--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -467,6 +467,39 @@ async fn main() {
 
     // }}}
 
+    // {{{ 주식잔고조회
+    let balance = api
+        .order
+        .inquire_balance(None, None, None, None, None)
+        .await
+        .unwrap();
+    if balance.rt_cd() != "0" {
+        panic!("잔고조회 Error Response: {:?}", balance);
+    }
+    info!("주식잔고조회 Response: {:?}", balance);
+
+    // 보유종목 출력
+    for item in balance.output1() {
+        info!(
+            "보유종목: {} ({}) 수량: {} 평가손익: {}",
+            item.prdt_name(),
+            item.pdno(),
+            item.hldg_qty(),
+            item.evlu_pfls_amt(),
+        );
+    }
+
+    // 계좌 요약 출력
+    for summary in balance.output2() {
+        info!(
+            "총평가금액: {}, 순자산: {}, 예수금: {}",
+            summary.tot_evlu_amt(),
+            summary.nass_amt(),
+            summary.dnca_tot_amt(),
+        );
+    }
+    // }}}
+
     // {{{ 삼성전자 호가 실시간 시세 구독(호가; KRX)
     let (rx, subscribe_response) = api
         .k_data

--- a/src/stock/order.rs
+++ b/src/stock/order.rs
@@ -248,8 +248,62 @@ impl Korea {
     // TODO: 주식일별주문체결조회[v1_국내주식-005]
     // [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-daily-ccld)
 
-    // TODO: 주식잔고조회[v1_국내주식-006]
-    // [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-balance)
+    /// 주식잔고조회[v1_국내주식-006]
+    /// [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-balance)
+    ///
+    /// 실전계좌: 최대 50건, 모의계좌: 최대 20건 / 초과분은 `ctx_area_fk100`/`ctx_area_nk100`으로 연속조회
+    pub async fn inquire_balance(
+        &self,
+        afhr_flpr_yn: Option<String>,
+        inqr_dvsn: Option<String>,
+        prcs_dvsn: Option<String>,
+        ctx_area_fk100: Option<String>,
+        ctx_area_nk100: Option<String>,
+    ) -> Result<response::stock::order::balance::InquireBalance, Error> {
+        let tr_id = match self.environment {
+            Environment::Real => TrId::RealInquireBalance,
+            Environment::Virtual => TrId::VirtualInquireBalance,
+        };
+        let param = request::stock::order::Query::InquireBalance::new(
+            self.account.cano.clone(),
+            self.account.acnt_prdt_cd.clone(),
+            afhr_flpr_yn,
+            inqr_dvsn,
+            prcs_dvsn,
+            ctx_area_fk100,
+            ctx_area_nk100,
+        );
+        let url = format!(
+            "{}/uapi/domestic-stock/v1/trading/inquire-balance",
+            self.endpoint_url
+        );
+        let params = param.into_iter();
+        let url = reqwest::Url::parse_with_params(&url, &params)?;
+        let tr_id_str: String = tr_id.into();
+        crate::wait(self.environment).await;
+        let result = self
+            .client
+            .get(url)
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                match self.auth.get_token() {
+                    Some(token) => format!("Bearer {}", token),
+                    None => {
+                        return Err(Error::AuthInitFailed("token"));
+                    }
+                },
+            )
+            .header("appkey", self.auth.get_appkey())
+            .header("appsecret", self.auth.get_appsecret())
+            .header("tr_id", tr_id_str)
+            .send()
+            .await?
+            .json::<response::stock::order::balance::InquireBalance>()
+            .await?;
+        crate::update_last_call();
+        Ok(result)
+    }
 
     // TODO: 매수가능조회[v1_국내주식-007]
     // [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-psbl-order)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -436,6 +436,11 @@ pub enum TrId {
     RealRealtimeMyExec,
     #[serde(rename = "H0STCNI9")]
     VirtualRealtimeMyExec,
+    // Balance
+    #[serde(rename = "TTTC8434R")]
+    RealInquireBalance,
+    #[serde(rename = "VTTC8434R")]
+    VirtualInquireBalance,
     // PingPong
     #[serde(rename = "PINGPONG")]
     PingPong,
@@ -468,6 +473,9 @@ impl Into<String> for TrId {
             TrId::RealtimeOrdbUnion => "H0UNASP0",
             TrId::RealRealtimeMyExec => "H0STCNI0",
             TrId::VirtualRealtimeMyExec => "H0STCNI9",
+            // Balance
+            TrId::RealInquireBalance => "TTTC8434R",
+            TrId::VirtualInquireBalance => "VTTC8434R",
             // PingPong
             TrId::PingPong => "PINGPONG",
         }
@@ -505,6 +513,9 @@ impl std::str::FromStr for TrId {
             "H0UNASP0" => Ok(TrId::RealtimeOrdbUnion),
             "H0STCNI0" => Ok(TrId::RealRealtimeMyExec),
             "H0STCNI9" => Ok(TrId::VirtualRealtimeMyExec),
+            // Balance
+            "TTTC8434R" => Ok(TrId::RealInquireBalance),
+            "VTTC8434R" => Ok(TrId::VirtualInquireBalance),
             // PingPong
             "PINGPONG" => Ok(TrId::PingPong),
             _ => Err(Error::BrokenProtocol("TrId", s.to_string())),

--- a/src/types/request/stock/order.rs
+++ b/src/types/request/stock/order.rs
@@ -283,3 +283,100 @@ pub mod Body {
         }
     }
 }
+
+#[allow(non_snake_case)]
+pub mod Query {
+    use getset::{Getters, Setters};
+    use serde::{Deserialize, Serialize};
+
+    /// 주식잔고조회 Query Parameter [v1_국내주식-006]
+    #[derive(Debug, Clone, PartialEq, Getters, Setters, Serialize, Deserialize)]
+    pub struct InquireBalance {
+        /// 종합계좌번호 (계좌번호 체계(8-2)의 앞 8자리)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CANO")]
+        cano: String,
+        /// 계좌상품코드 (계좌번호 체계(8-2)의 뒤 2자리)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "ACNT_PRDT_CD")]
+        acnt_prdt_cd: String,
+        /// 시간외단일가여부 (N: 기본값)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "AFHR_FLPR_YN")]
+        afhr_flpr_yn: String,
+        /// 오프라인여부 (공란: 기본값)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "OFL_YN")]
+        ofl_yn: String,
+        /// 조회구분 (01: 대출일별)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_DVSN")]
+        inqr_dvsn: String,
+        /// 단가구분 (01: 기본값)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "UNPR_DVSN")]
+        unpr_dvsn: String,
+        /// 펀드결제분포함여부 (N: 포함하지 않음)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "FUND_STTL_ICLD_YN")]
+        fund_sttl_icld_yn: String,
+        /// 융자금액자동상환여부 (N: 기본값)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "FNCG_AMT_AUTO_RDPT_YN")]
+        fncg_amt_auto_rdpt_yn: String,
+        /// 처리구분 (00: 전일매매포함, 01: 전일매매미포함)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "PRCS_DVSN")]
+        prcs_dvsn: String,
+        /// 연속조회검색조건100 (공란: 최초 조회)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CTX_AREA_FK100")]
+        ctx_area_fk100: String,
+        /// 연속조회키100 (공란: 최초 조회)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CTX_AREA_NK100")]
+        ctx_area_nk100: String,
+    }
+
+    impl InquireBalance {
+        pub fn new(
+            cano: String,
+            acnt_prdt_cd: String,
+            afhr_flpr_yn: Option<String>,
+            inqr_dvsn: Option<String>,
+            prcs_dvsn: Option<String>,
+            ctx_area_fk100: Option<String>,
+            ctx_area_nk100: Option<String>,
+        ) -> Self {
+            Self {
+                cano,
+                acnt_prdt_cd,
+                afhr_flpr_yn: afhr_flpr_yn.unwrap_or_else(|| "N".to_string()),
+                ofl_yn: String::new(),
+                inqr_dvsn: inqr_dvsn.unwrap_or_else(|| "01".to_string()),
+                unpr_dvsn: "01".to_string(),
+                fund_sttl_icld_yn: "N".to_string(),
+                fncg_amt_auto_rdpt_yn: "N".to_string(),
+                prcs_dvsn: prcs_dvsn.unwrap_or_else(|| "00".to_string()),
+                ctx_area_fk100: ctx_area_fk100.unwrap_or_default(),
+                ctx_area_nk100: ctx_area_nk100.unwrap_or_default(),
+            }
+        }
+
+        pub fn into_iter(&self) -> [(&'static str, String); 11] {
+            [
+                ("CANO", self.cano.clone()),
+                ("ACNT_PRDT_CD", self.acnt_prdt_cd.clone()),
+                ("AFHR_FLPR_YN", self.afhr_flpr_yn.clone()),
+                ("OFL_YN", self.ofl_yn.clone()),
+                ("INQR_DVSN", self.inqr_dvsn.clone()),
+                ("UNPR_DVSN", self.unpr_dvsn.clone()),
+                ("FUND_STTL_ICLD_YN", self.fund_sttl_icld_yn.clone()),
+                ("FNCG_AMT_AUTO_RDPT_YN", self.fncg_amt_auto_rdpt_yn.clone()),
+                ("PRCS_DVSN", self.prcs_dvsn.clone()),
+                ("CTX_AREA_FK100", self.ctx_area_fk100.clone()),
+                ("CTX_AREA_NK100", self.ctx_area_nk100.clone()),
+            ]
+        }
+    }
+}

--- a/src/types/response/stock/order.rs
+++ b/src/types/response/stock/order.rs
@@ -136,3 +136,195 @@ pub mod Output {
         mgco_aptm_odno: String,
     }
 }
+
+/// 주식잔고조회 response types [v1_국내주식-006]
+pub mod balance {
+    use getset::Getters;
+    use serde::{Deserialize, Serialize};
+
+    /// 주식잔고조회 응답 Body
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct InquireBalance {
+        /// 0: 성공, 0 이외의 값: 실패
+        #[getset(get = "pub")]
+        rt_cd: String,
+        /// 응답코드
+        #[getset(get = "pub")]
+        msg_cd: String,
+        /// 응답메시지
+        #[getset(get = "pub")]
+        msg1: String,
+        /// 연속조회검색조건100
+        #[getset(get = "pub")]
+        ctx_area_fk100: Option<String>,
+        /// 연속조회키100
+        #[getset(get = "pub")]
+        ctx_area_nk100: Option<String>,
+        /// 보유종목 목록
+        #[getset(get = "pub")]
+        output1: Vec<BalanceItem>,
+        /// 계좌 요약 정보
+        #[getset(get = "pub")]
+        output2: Vec<BalanceSummary>,
+    }
+
+    /// output1 - 보유종목 상세
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct BalanceItem {
+        /// 상품번호 (종목번호 뒷 6자리)
+        #[getset(get = "pub")]
+        pdno: String,
+        /// 상품명 (종목명)
+        #[getset(get = "pub")]
+        prdt_name: String,
+        /// 매매구분명 (현금/신용 등)
+        #[getset(get = "pub")]
+        trad_dvsn_name: String,
+        /// 전일매수수량
+        #[getset(get = "pub")]
+        bfdy_buy_qty: String,
+        /// 전일매도수량
+        #[getset(get = "pub")]
+        bfdy_sll_qty: String,
+        /// 금일매수수량
+        #[getset(get = "pub")]
+        thdt_buyqty: String,
+        /// 금일매도수량
+        #[getset(get = "pub")]
+        thdt_sll_qty: String,
+        /// 보유수량
+        #[getset(get = "pub")]
+        hldg_qty: String,
+        /// 주문가능수량
+        #[getset(get = "pub")]
+        ord_psbl_qty: String,
+        /// 매입평균가격
+        #[getset(get = "pub")]
+        pchs_avg_pric: String,
+        /// 매입금액
+        #[getset(get = "pub")]
+        pchs_amt: String,
+        /// 현재가
+        #[getset(get = "pub")]
+        prpr: String,
+        /// 평가금액
+        #[getset(get = "pub")]
+        evlu_amt: String,
+        /// 평가손익금액
+        #[getset(get = "pub")]
+        evlu_pfls_amt: String,
+        /// 평가손익율
+        #[getset(get = "pub")]
+        evlu_pfls_rt: String,
+        /// 평가수익율
+        #[getset(get = "pub")]
+        evlu_erng_rt: String,
+        /// 대출일자
+        #[getset(get = "pub")]
+        loan_dt: String,
+        /// 대출금액
+        #[getset(get = "pub")]
+        loan_amt: String,
+        /// 대주매각대금
+        #[getset(get = "pub")]
+        stln_slng_chgs: String,
+        /// 만기일자
+        #[getset(get = "pub")]
+        expd_dt: String,
+        /// 등락율
+        #[getset(get = "pub")]
+        fltt_rt: String,
+        /// 전일대비증감
+        #[getset(get = "pub")]
+        bfdy_cprs_icdc: String,
+        /// 종목증거금율명
+        #[getset(get = "pub")]
+        item_mgna_rt_name: String,
+        /// 보증금율명
+        #[getset(get = "pub")]
+        grta_rt_name: String,
+        /// 대용가격
+        #[getset(get = "pub")]
+        sbst_pric: String,
+        /// 주식대출단가
+        #[getset(get = "pub")]
+        stck_loan_unpr: String,
+    }
+
+    /// output2 - 계좌 요약
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct BalanceSummary {
+        /// 예수금총금액
+        #[getset(get = "pub")]
+        dnca_tot_amt: String,
+        /// 익일정산금액 (D+1 예수금)
+        #[getset(get = "pub")]
+        nxdy_excc_amt: String,
+        /// 가수도정산금액 (D+2 예수금)
+        #[getset(get = "pub")]
+        prvs_rcdl_excc_amt: String,
+        /// CMA평가금액
+        #[getset(get = "pub")]
+        cma_evlu_amt: String,
+        /// 전일매수금액
+        #[getset(get = "pub")]
+        bfdy_buy_amt: String,
+        /// 금일매수금액
+        #[getset(get = "pub")]
+        thdt_buy_amt: String,
+        /// 익일자동상환금액
+        #[getset(get = "pub")]
+        nxdy_auto_rdpt_amt: String,
+        /// 전일매도금액
+        #[getset(get = "pub")]
+        bfdy_sll_amt: String,
+        /// 금일매도금액
+        #[getset(get = "pub")]
+        thdt_sll_amt: String,
+        /// D+2자동상환금액
+        #[getset(get = "pub")]
+        d2_auto_rdpt_amt: String,
+        /// 전일제비용금액
+        #[getset(get = "pub")]
+        bfdy_tlex_amt: String,
+        /// 금일제비용금액
+        #[getset(get = "pub")]
+        thdt_tlex_amt: String,
+        /// 총대출금액
+        #[getset(get = "pub")]
+        tot_loan_amt: String,
+        /// 유가평가금액
+        #[getset(get = "pub")]
+        scts_evlu_amt: String,
+        /// 총평가금액 (유가증권 평가금액 + D+2 예수금)
+        #[getset(get = "pub")]
+        tot_evlu_amt: String,
+        /// 순자산금액
+        #[getset(get = "pub")]
+        nass_amt: String,
+        /// 융자금자동상환여부
+        #[getset(get = "pub")]
+        fncg_gld_auto_rdpt_yn: String,
+        /// 매입금액합계금액
+        #[getset(get = "pub")]
+        pchs_amt_smtl_amt: String,
+        /// 평가금액합계금액
+        #[getset(get = "pub")]
+        evlu_amt_smtl_amt: String,
+        /// 평가손익합계금액
+        #[getset(get = "pub")]
+        evlu_pfls_smtl_amt: String,
+        /// 총대주매각대금
+        #[getset(get = "pub")]
+        tot_stln_slng_chgs: String,
+        /// 전일총자산평가금액
+        #[getset(get = "pub")]
+        bfdy_tot_asst_evlu_amt: String,
+        /// 자산증감액
+        #[getset(get = "pub")]
+        asst_icdc_amt: String,
+        /// 자산증감수익율
+        #[getset(get = "pub")]
+        asst_icdc_erng_rt: String,
+    }
+}


### PR DESCRIPTION
## 변경사항

### `src/types/mod.rs`
- `TrId::RealInquireBalance` (`TTTC8434R`), `TrId::VirtualInquireBalance` (`VTTC8434R`) 추가

### `src/types/request/stock/order.rs`
- `Query::InquireBalance` 추가 — GET query parameter 구조체
- `into_iter()` 로 11개 파라미터 반환
- 기본값: `AFHR_FLPR_YN=N`, `INQR_DVSN=01`, `UNPR_DVSN=01`, `FUND_STTL_ICLD_YN=N`, `FNCG_AMT_AUTO_RDPT_YN=N`, `PRCS_DVSN=00`

### `src/types/response/stock/order.rs`
- `balance::InquireBalance` — 응답 Body (`rt_cd`, `msg_cd`, `msg1`, 연속조회키, output1/2)
- `balance::BalanceItem` — output1 보유종목 상세 (26개 필드)
- `balance::BalanceSummary` — output2 계좌 요약 (24개 필드)

### `src/stock/order.rs`
- `Korea::inquire_balance()` 구현
- 연속조회: `ctx_area_fk100` / `ctx_area_nk100` 파라미터로 페이지네이션 지원
- 실전: 최대 50건 / 모의: 최대 20건

## 참고
- API 문서: `v1_국내주식-006` inquire-balance
- 실전 TR_ID: `TTTC8434R` / 모의 TR_ID: `VTTC8434R`