### PR TITLE
feat: implement 주식일별주문체결조회 [v1_국내주식-005]

### DIFF
--- a/src/stock/order.rs
+++ b/src/stock/order.rs
@@ -249,6 +249,7 @@ impl Korea {
     /// [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-daily-ccld)
     ///
     /// 기간별 주문 및 체결 내역을 조회합니다.
+    /// 조회 시작일이 3개월 이내이면 Recent TR, 3개월 이전이면 Past TR을 자동으로 사용합니다.
     /// 실전계좌: 최대 50건, 모의계좌: 최대 20건 / 초과분은 `ctx_area_fk100`/`ctx_area_nk100`으로 연속조회
     pub async fn inquire_daily_ccld(
         &self,
@@ -265,9 +266,29 @@ impl Korea {
         ctx_area_fk100: Option<String>,
         ctx_area_nk100: Option<String>,
     ) -> Result<response::stock::order::daily_ccld::InquireDailyCcld, Error> {
+        // 조회 시작일이 3개월 이내이면 Recent, 이전이면 Past TR 사용
+        let three_months_ago = chrono::Utc::now()
+            .with_timezone(&chrono_tz::Asia::Seoul)
+            .checked_sub_signed(chrono::Duration::days(90))
+            .unwrap()
+            .format("%Y%m%d")
+            .to_string();
+        let is_recent = inqr_strt_dt >= three_months_ago.as_str();
         let tr_id = match self.environment {
-            Environment::Real => TrId::RealInquireDailyCcld,
-            Environment::Virtual => TrId::VirtualInquireDailyCcld,
+            Environment::Real => {
+                if is_recent {
+                    TrId::RealInquireDailyCcldRecent
+                } else {
+                    TrId::RealInquireDailyCcldPast
+                }
+            }
+            Environment::Virtual => {
+                if is_recent {
+                    TrId::VirtualInquireDailyCcldRecent
+                } else {
+                    TrId::VirtualInquireDailyCcldPast
+                }
+            }
         };
         let param = request::stock::order::Query::InquireDailyCcld::new(
             self.account.cano.clone(),

--- a/src/stock/order.rs
+++ b/src/stock/order.rs
@@ -2,6 +2,7 @@ use crate::types::{
     request, response, Account, CorrectionClass, CreditType, Direction, Environment, OrderClass,
     Price, Quantity, TargetExchange, TrId,
 };
+
 use crate::{auth, Error};
 
 #[derive(Clone, Debug)]
@@ -265,6 +266,7 @@ impl Korea {
         inqr_dvsn_1: Option<String>,
         ctx_area_fk100: Option<String>,
         ctx_area_nk100: Option<String>,
+        excg_id_dvsn_cd: Option<TargetExchange>,
     ) -> Result<response::stock::order::daily_ccld::InquireDailyCcld, Error> {
         // 조회 시작일이 3개월 이내이면 Recent, 이전이면 Past TR 사용
         let three_months_ago = chrono::Utc::now()
@@ -305,6 +307,7 @@ impl Korea {
             inqr_dvsn_1,
             ctx_area_fk100,
             ctx_area_nk100,
+            excg_id_dvsn_cd,
         );
         let url = format!(
             "{}/uapi/domestic-stock/v1/trading/inquire-daily-ccld",

--- a/src/stock/order.rs
+++ b/src/stock/order.rs
@@ -245,8 +245,77 @@ impl Korea {
     // TODO: 주식정정취소가능주문조회[v1_국내주식-004]
     // [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-psbl-rvsecncl)
 
-    // TODO: 주식일별주문체결조회[v1_국내주식-005]
-    // [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-daily-ccld)
+    /// 주식일별주문체결조회[v1_국내주식-005]
+    /// [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-daily-ccld)
+    ///
+    /// 기간별 주문 및 체결 내역을 조회합니다.
+    /// 실전계좌: 최대 50건, 모의계좌: 최대 20건 / 초과분은 `ctx_area_fk100`/`ctx_area_nk100`으로 연속조회
+    pub async fn inquire_daily_ccld(
+        &self,
+        inqr_strt_dt: &str,
+        inqr_end_dt: &str,
+        sll_buy_dvsn_cd: Option<String>,
+        inqr_dvsn: Option<String>,
+        pdno: Option<String>,
+        ccld_dvsn: Option<String>,
+        ord_gno_brno: Option<String>,
+        odno: Option<String>,
+        inqr_dvsn_3: Option<String>,
+        inqr_dvsn_1: Option<String>,
+        ctx_area_fk100: Option<String>,
+        ctx_area_nk100: Option<String>,
+    ) -> Result<response::stock::order::daily_ccld::InquireDailyCcld, Error> {
+        let tr_id = match self.environment {
+            Environment::Real => TrId::RealInquireDailyCcld,
+            Environment::Virtual => TrId::VirtualInquireDailyCcld,
+        };
+        let param = request::stock::order::Query::InquireDailyCcld::new(
+            self.account.cano.clone(),
+            self.account.acnt_prdt_cd.clone(),
+            inqr_strt_dt.to_string(),
+            inqr_end_dt.to_string(),
+            sll_buy_dvsn_cd,
+            inqr_dvsn,
+            pdno,
+            ccld_dvsn,
+            ord_gno_brno,
+            odno,
+            inqr_dvsn_3,
+            inqr_dvsn_1,
+            ctx_area_fk100,
+            ctx_area_nk100,
+        );
+        let url = format!(
+            "{}/uapi/domestic-stock/v1/trading/inquire-daily-ccld",
+            self.endpoint_url
+        );
+        let params = param.into_iter();
+        let url = reqwest::Url::parse_with_params(&url, &params)?;
+        let tr_id_str: String = tr_id.into();
+        crate::wait(self.environment).await;
+        let result = self
+            .client
+            .get(url)
+            .header("Content-Type", "application/json")
+            .header(
+                "Authorization",
+                match self.auth.get_token() {
+                    Some(token) => format!("Bearer {}", token),
+                    None => {
+                        return Err(Error::AuthInitFailed("token"));
+                    }
+                },
+            )
+            .header("appkey", self.auth.get_appkey())
+            .header("appsecret", self.auth.get_appsecret())
+            .header("tr_id", tr_id_str)
+            .send()
+            .await?
+            .json::<response::stock::order::daily_ccld::InquireDailyCcld>()
+            .await?;
+        crate::update_last_call();
+        Ok(result)
+    }
 
     /// 주식잔고조회[v1_국내주식-006]
     /// [Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-balance)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -444,11 +444,16 @@ pub enum TrId {
     // InquirePsblRvsecncl (주식정정취소가능주문조회, 실전투자만 지원)
     #[serde(rename = "TTTC0084R")]
     RealInquirePsblRvsecncl,
-    // InquireDailyCcld (주식일별주문체결조회)
-    #[serde(rename = "TTTC8001R")]
-    RealInquireDailyCcld,
-    #[serde(rename = "VTTC8001R")]
-    VirtualInquireDailyCcld,
+    // InquireDailyCcld (주식일별주문체결조회(3개월 이내))
+    #[serde(rename = "TTTC0081R")]
+    RealInquireDailyCcldRecent,
+    #[serde(rename = "VTTC0081R")]
+    VirtualInquireDailyCcldRecent,
+    // InquireDailyCcld (주식일별주문체결조회(3개월 이전))
+    #[serde(rename = "CTSC9215R")]
+    RealInquireDailyCcldPast,
+    #[serde(rename = "VTSC9215R")]
+    VirtualInquireDailyCcldPast,
     // PingPong
     #[serde(rename = "PINGPONG")]
     PingPong,
@@ -487,8 +492,10 @@ impl Into<String> for TrId {
             // InquirePsblRvsecncl (실전투자만 지원)
             TrId::RealInquirePsblRvsecncl => "TTTC0084R",
             // InquireDailyCcld
-            TrId::RealInquireDailyCcld => "TTTC8001R",
-            TrId::VirtualInquireDailyCcld => "VTTC8001R",
+            TrId::RealInquireDailyCcldRecent => "TTTC0081R",
+            TrId::VirtualInquireDailyCcldRecent => "VTTC0081R",
+            TrId::RealInquireDailyCcldPast => "CTSC9215R",
+            TrId::VirtualInquireDailyCcldPast => "VTSC9215R",
             // PingPong
             TrId::PingPong => "PINGPONG",
         }
@@ -532,8 +539,10 @@ impl std::str::FromStr for TrId {
             // InquirePsblRvsecncl (실전투자만 지원)
             "TTTC0084R" => Ok(TrId::RealInquirePsblRvsecncl),
             // InquireDailyCcld
-            "TTTC8001R" => Ok(TrId::RealInquireDailyCcld),
-            "VTTC8001R" => Ok(TrId::VirtualInquireDailyCcld),
+            "TTTC0081R" => Ok(TrId::RealInquireDailyCcldRecent),
+            "VTTC0081R" => Ok(TrId::VirtualInquireDailyCcldRecent),
+            "CTSC9215R" => Ok(TrId::RealInquireDailyCcldPast),
+            "VTSC9215R" => Ok(TrId::VirtualInquireDailyCcldPast),
             // PingPong
             "PINGPONG" => Ok(TrId::PingPong),
             _ => Err(Error::BrokenProtocol("TrId", s.to_string())),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -444,6 +444,11 @@ pub enum TrId {
     // InquirePsblRvsecncl (주식정정취소가능주문조회, 실전투자만 지원)
     #[serde(rename = "TTTC0084R")]
     RealInquirePsblRvsecncl,
+    // InquireDailyCcld (주식일별주문체결조회)
+    #[serde(rename = "TTTC8001R")]
+    RealInquireDailyCcld,
+    #[serde(rename = "VTTC8001R")]
+    VirtualInquireDailyCcld,
     // PingPong
     #[serde(rename = "PINGPONG")]
     PingPong,
@@ -481,6 +486,9 @@ impl Into<String> for TrId {
             TrId::VirtualInquireBalance => "VTTC8434R",
             // InquirePsblRvsecncl (실전투자만 지원)
             TrId::RealInquirePsblRvsecncl => "TTTC0084R",
+            // InquireDailyCcld
+            TrId::RealInquireDailyCcld => "TTTC8001R",
+            TrId::VirtualInquireDailyCcld => "VTTC8001R",
             // PingPong
             TrId::PingPong => "PINGPONG",
         }
@@ -523,6 +531,9 @@ impl std::str::FromStr for TrId {
             "VTTC8434R" => Ok(TrId::VirtualInquireBalance),
             // InquirePsblRvsecncl (실전투자만 지원)
             "TTTC0084R" => Ok(TrId::RealInquirePsblRvsecncl),
+            // InquireDailyCcld
+            "TTTC8001R" => Ok(TrId::RealInquireDailyCcld),
+            "VTTC8001R" => Ok(TrId::VirtualInquireDailyCcld),
             // PingPong
             "PINGPONG" => Ok(TrId::PingPong),
             _ => Err(Error::BrokenProtocol("TrId", s.to_string())),

--- a/src/types/request/stock/order.rs
+++ b/src/types/request/stock/order.rs
@@ -286,6 +286,7 @@ pub mod Body {
 
 #[allow(non_snake_case)]
 pub mod Query {
+    use crate::types::TargetExchange;
     use getset::{Getters, Setters};
     use serde::{Deserialize, Serialize};
 
@@ -436,6 +437,129 @@ pub mod Query {
                 ("CTX_AREA_NK100", self.ctx_area_nk100.clone()),
                 ("INQR_DVSN_1", self.inqr_dvsn_1.clone()),
                 ("INQR_DVSN_2", self.inqr_dvsn_2.clone()),
+            ]
+        }
+    }
+
+    /// 주식일별주문체결조회 Query Parameter [v1_국내주식-005]
+    #[derive(Debug, Clone, PartialEq, Getters, Setters, Serialize, Deserialize)]
+    pub struct InquireDailyCcld {
+        /// 종합계좌번호 (계좌번호 체계(8-2)의 앞 8자리)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CANO")]
+        cano: String,
+        /// 계좌상품코드 (계좌번호 체계(8-2)의 뒤 2자리)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "ACNT_PRDT_CD")]
+        acnt_prdt_cd: String,
+        /// 조회시작일자 (YYYYMMDD)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_STRT_DT")]
+        inqr_strt_dt: String,
+        /// 조회종료일자 (YYYYMMDD)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_END_DT")]
+        inqr_end_dt: String,
+        /// 매도매수구분코드 (00: 전체, 01: 매도, 02: 매수)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "SLL_BUY_DVSN_CD")]
+        sll_buy_dvsn_cd: String,
+        /// 조회구분 (00: 역순, 01: 정순)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_DVSN")]
+        inqr_dvsn: String,
+        /// 종목번호 (공란: 전체)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "PDNO")]
+        pdno: String,
+        /// 체결구분 (00: 전체, 01: 체결, 02: 미체결)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CCLD_DVSN")]
+        ccld_dvsn: String,
+        /// 주문채번지점번호 (공란)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "ORD_GNO_BRNO")]
+        ord_gno_brno: String,
+        /// 주문번호 (공란)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "ODNO")]
+        odno: String,
+        /// 조회구분3 (00: 전체, 01: 현금, 02: 융자, 03: 대출, 04: 대주)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_DVSN_3")]
+        inqr_dvsn_3: String,
+        /// 조회구분1 (공란: 전체, 1: ELW, 2: 프리보드)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "INQR_DVSN_1")]
+        inqr_dvsn_1: String,
+        /// 연속조회검색조건100 (공란: 최초 조회)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CTX_AREA_FK100")]
+        ctx_area_fk100: String,
+        /// 연속조회키100 (공란: 최초 조회)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "CTX_AREA_NK100")]
+        ctx_area_nk100: String,
+        /// 거래소ID구분코드 (KRX/NXT/SOR)
+        #[getset(get = "pub", set = "pub")]
+        #[serde(rename = "EXCG_ID_DVSN_CD")]
+        excg_id_dvsn_cd: TargetExchange,
+    }
+
+    impl InquireDailyCcld {
+        pub fn new(
+            cano: String,
+            acnt_prdt_cd: String,
+            inqr_strt_dt: String,
+            inqr_end_dt: String,
+            sll_buy_dvsn_cd: Option<String>,
+            inqr_dvsn: Option<String>,
+            pdno: Option<String>,
+            ccld_dvsn: Option<String>,
+            ord_gno_brno: Option<String>,
+            odno: Option<String>,
+            inqr_dvsn_3: Option<String>,
+            inqr_dvsn_1: Option<String>,
+            ctx_area_fk100: Option<String>,
+            ctx_area_nk100: Option<String>,
+            excg_id_dvsn_cd: Option<TargetExchange>,
+        ) -> Self {
+            Self {
+                cano,
+                acnt_prdt_cd,
+                inqr_strt_dt,
+                inqr_end_dt,
+                sll_buy_dvsn_cd: sll_buy_dvsn_cd.unwrap_or_else(|| "00".to_string()),
+                inqr_dvsn: inqr_dvsn.unwrap_or_else(|| "00".to_string()),
+                pdno: pdno.unwrap_or_default(),
+                ccld_dvsn: ccld_dvsn.unwrap_or_else(|| "00".to_string()),
+                ord_gno_brno: ord_gno_brno.unwrap_or_default(),
+                odno: odno.unwrap_or_default(),
+                inqr_dvsn_3: inqr_dvsn_3.unwrap_or_else(|| "00".to_string()),
+                inqr_dvsn_1: inqr_dvsn_1.unwrap_or_default(),
+                ctx_area_fk100: ctx_area_fk100.unwrap_or_default(),
+                ctx_area_nk100: ctx_area_nk100.unwrap_or_default(),
+                excg_id_dvsn_cd: excg_id_dvsn_cd.unwrap_or_default(),
+            }
+        }
+
+        pub fn into_iter(&self) -> [(&'static str, String); 15] {
+            [
+                ("CANO", self.cano.clone()),
+                ("ACNT_PRDT_CD", self.acnt_prdt_cd.clone()),
+                ("INQR_STRT_DT", self.inqr_strt_dt.clone()),
+                ("INQR_END_DT", self.inqr_end_dt.clone()),
+                ("SLL_BUY_DVSN_CD", self.sll_buy_dvsn_cd.clone()),
+                ("INQR_DVSN", self.inqr_dvsn.clone()),
+                ("PDNO", self.pdno.clone()),
+                ("CCLD_DVSN", self.ccld_dvsn.clone()),
+                ("ORD_GNO_BRNO", self.ord_gno_brno.clone()),
+                ("ODNO", self.odno.clone()),
+                ("INQR_DVSN_3", self.inqr_dvsn_3.clone()),
+                ("INQR_DVSN_1", self.inqr_dvsn_1.clone()),
+                ("CTX_AREA_FK100", self.ctx_area_fk100.clone()),
+                ("CTX_AREA_NK100", self.ctx_area_nk100.clone()),
+                ("EXCG_ID_DVSN_CD", format!("{:?}", self.excg_id_dvsn_cd)),
             ]
         }
     }

--- a/src/types/response/stock/order.rs
+++ b/src/types/response/stock/order.rs
@@ -137,6 +137,150 @@ pub mod Output {
     }
 }
 
+/// 주식일별주문체결조회 response types [v1_국내주식-005]
+pub mod daily_ccld {
+    use getset::Getters;
+    use serde::{Deserialize, Serialize};
+
+    /// 주식일별주문체결조회 응답 Body
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct InquireDailyCcld {
+        /// 0: 성공, 0 이외의 값: 실패
+        #[getset(get = "pub")]
+        rt_cd: String,
+        /// 응답코드
+        #[getset(get = "pub")]
+        msg_cd: String,
+        /// 응답메시지
+        #[getset(get = "pub")]
+        msg1: String,
+        /// 연속조회검색조건100
+        #[getset(get = "pub")]
+        ctx_area_fk100: Option<String>,
+        /// 연속조회키100
+        #[getset(get = "pub")]
+        ctx_area_nk100: Option<String>,
+        /// 주문체결 목록
+        #[getset(get = "pub")]
+        output1: Vec<DailyCcldItem>,
+        /// 합계 정보
+        #[getset(get = "pub")]
+        output2: Vec<DailyCcldSummary>,
+    }
+
+    /// output1 - 주문체결 상세
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct DailyCcldItem {
+        /// 주문일자 (YYYYMMDD)
+        #[getset(get = "pub")]
+        ord_dt: String,
+        /// 주문채번지점번호
+        #[getset(get = "pub")]
+        ord_gno_brno: String,
+        /// 주문번호
+        #[getset(get = "pub")]
+        odno: String,
+        /// 원주문번호
+        #[getset(get = "pub")]
+        orgn_odno: String,
+        /// 주문구분명
+        #[getset(get = "pub")]
+        ord_dvsn_name: String,
+        /// 매도매수구분코드 (01: 매도, 02: 매수)
+        #[getset(get = "pub")]
+        sll_buy_dvsn_cd: String,
+        /// 매도매수구분코드명
+        #[getset(get = "pub")]
+        sll_buy_dvsn_cd_name: String,
+        /// 상품번호 (종목코드)
+        #[getset(get = "pub")]
+        pdno: String,
+        /// 상품명 (종목명)
+        #[getset(get = "pub")]
+        prdt_name: String,
+        /// 주문수량
+        #[getset(get = "pub")]
+        ord_qty: String,
+        /// 주문단가 (1주당 주문가격)
+        #[getset(get = "pub")]
+        ord_unpr: String,
+        /// 주문시각 (HHMMSS)
+        #[getset(get = "pub")]
+        ord_tmd: String,
+        /// 총체결수량
+        #[getset(get = "pub")]
+        tot_ccld_qty: String,
+        /// 평균가
+        #[getset(get = "pub")]
+        avg_prvs: String,
+        /// 취소여부 (Y: 취소, N: 정상)
+        #[getset(get = "pub")]
+        cncl_yn: String,
+        /// 총체결금액
+        #[getset(get = "pub")]
+        tot_ccld_amt: String,
+        /// 대출일자
+        #[getset(get = "pub")]
+        loan_dt: String,
+        /// 주문구분코드
+        #[getset(get = "pub")]
+        ord_dvsn_cd: String,
+        /// 취소확인수량
+        #[getset(get = "pub")]
+        cncl_cfrm_qty: String,
+        /// 잔량수량
+        #[getset(get = "pub")]
+        rmn_qty: String,
+        /// 거부수량
+        #[getset(get = "pub")]
+        rjct_qty: String,
+        /// 체결조건명
+        #[getset(get = "pub")]
+        ccld_cndt_name: String,
+        /// 조회IP주소
+        #[getset(get = "pub")]
+        inqr_ip_addr: String,
+        /// 복합주문부모주문접수구분명
+        #[getset(get = "pub")]
+        cpbc_ordp_ord_rcit_dvsn_name: String,
+        /// 복합주문부모알림방법명
+        #[getset(get = "pub")]
+        cpbc_ordp_infm_mthd_name: String,
+        /// 알림시각
+        #[getset(get = "pub")]
+        infm_tmd: String,
+        /// 연락전화번호
+        #[getset(get = "pub")]
+        ctac_tlno: String,
+        /// 상품유형코드
+        #[getset(get = "pub")]
+        prdt_type_cd: String,
+        /// 거래소구분코드
+        #[getset(get = "pub")]
+        excg_dvsn_cd: String,
+    }
+
+    /// output2 - 합계
+    #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize, Getters)]
+    pub struct DailyCcldSummary {
+        /// 총주문수량
+        #[getset(get = "pub")]
+        tot_ord_qty: String,
+        /// 총체결수량
+        #[getset(get = "pub")]
+        tot_ccld_qty: String,
+        /// 총체결금액
+        #[getset(get = "pub")]
+        tot_ccld_amt: String,
+        /// 추정제비용합계
+        #[getset(get = "pub")]
+        prsm_tlex_smtl: String,
+        /// 매입평균가격
+        #[getset(get = "pub")]
+        pchs_avg_pric: String,
+    }
+}
+
 /// 주식잔고조회 response types [v1_국내주식-006]
 pub mod balance {
     use getset::Getters;


### PR DESCRIPTION
## 변경 사항

### 신규 구현: `v1_국내주식-005` 주식일별주문체결조회
[API Docs](https://apiportal.koreainvestment.com/apiservice-apiservice?/uapi/domestic-stock/v1/trading/inquire-daily-ccld)

기간별 주문 및 체결 내역을 조회하는 API를 구현했습니다.

---

### 변경 파일

#### `src/types/mod.rs`
- `TrId::RealInquireDailyCcld` (`TTTC8001R`) 추가
- `TrId::VirtualInquireDailyCcld` (`VTTC8001R`) 추가

#### `src/types/request/stock/order.rs`
- `Query::InquireDailyCcld` 추가
  - 필수: `CANO`, `ACNT_PRDT_CD`, `INQR_STRT_DT`, `INQR_END_DT`
  - 선택: `SLL_BUY_DVSN_CD`, `INQR_DVSN`, `PDNO`, `CCLD_DVSN`, `ORD_GNO_BRNO`, `ODNO`, `INQR_DVSN_3`, `INQR_DVSN_1`, `CTX_AREA_FK100/NK100`

#### `src/types/response/stock/order.rs`
- `daily_ccld` 모듈 추가
  - `InquireDailyCcld`: 응답 Body (rt_cd, msg_cd, msg1, 페이지 키, output1, output2)
  - `DailyCcldItem`: output1 - 주문체결 상세 (30개 필드)
  - `DailyCcldSummary`: output2 - 합계 (tot_ord_qty, tot_ccld_qty, tot_ccld_amt, prsm_tlex_smtl, pchs_avg_pric)

#### `src/stock/order.rs`
- `Korea::inquire_daily_ccld()` 메서드 구현
  - 실전/모의 환경 자동 분기
  - `ctx_area_fk100`/`ctx_area_nk100`으로 연속조회(페이지네이션) 지원

---

### 사용 예시

```rust
// 오늘 전체 주문/체결 내역 조회
let result = api.order.inquire_daily_ccld(
    "20260307", // inqr_strt_dt
    "20260307", // inqr_end_dt
    None, // sll_buy_dvsn_cd: 00=전체, 01=매도, 02=매수
    None, // inqr_dvsn: 00=역순, 01=정순
    None, // pdno: 종목코드 (공란=전체)
    None, // ccld_dvsn: 00=전체, 01=체결, 02=미체결
    None, // ord_gno_brno
    None, // odno
    None, // inqr_dvsn_3: 00=전체, 01=현금, 02=융자, 03=대출, 04=대주
    None, // inqr_dvsn_1
    None, // ctx_area_fk100 (연속조회 키, 최초 조회시 None)
    None, // ctx_area_nk100
).await?;

for item in result.output1() {
    println!("{} {} {} {}", item.pdno(), item.prdt_name(), item.ord_qty(), item.tot_ccld_qty());
}

// 합계
if let Some(summary) = result.output2().first() {
    println!("총체결금액: {}", summary.tot_ccld_amt());
}
```