### PR TITLE
B: fix ExecClass enum to handle empty case - unknown case...

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -855,7 +855,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "korea-investment-api"
-version = "3.0.4"
+version = "3.1.0"
 dependencies = [
  "aes",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "korea-investment-api"
 authors = ["Xanthorrhizol <xanthorrhizol@proton.me>"]
-version = "3.0.4"
+version = "3.1.0"
 edition = "2021"
 description = "Korea Investment API client for Rust(Not official)"
 repository = "https://github.com/Xanthorrhizol/korea-investment-api"

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -598,14 +598,15 @@ pub enum CreditType {
 
 /// 체결구분
 #[derive(Debug, Clone)]
-#[repr(i32)]
 pub enum ExecClass {
-    /// 매수(1)
-    Bid = 1,
-    /// 장전(3)
-    PreMarket = 3,
-    /// 매도(5)
-    Ask = 5,
+    /// 없음("")
+    None,
+    /// 매수("1")
+    Bid,
+    /// 장전("3")
+    PreMarket,
+    /// 매도("5")
+    Ask,
 }
 
 impl From<&str> for ExecClass {
@@ -614,6 +615,7 @@ impl From<&str> for ExecClass {
             "1" => Self::Bid,
             "3" => Self::PreMarket,
             "5" => Self::Ask,
+            "" => Self::None,
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
실시간 체결가 데이터에서 체결구분 필드가 빈 상태로 들어오는 경우가 있어 이를 핸들링했습니다.