### PR TITLE
여러 종목의 실시간 시세를 동시에 수신할 수 있도록 합니다.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "korea-investment-api"
-version = "3.1.1"
+version = "4.0.0"
 dependencies = [
  "aes",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +868,7 @@ name = "korea-investment-api"
 version = "3.1.1"
 dependencies = [
  "aes",
+ "async-trait",
  "base64 0.21.7",
  "cbc",
  "chrono",
@@ -876,6 +888,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml",
  "url",
+ "xan-actor",
  "xan-log",
 ]
 
@@ -1309,6 +1322,25 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -1948,6 +1980,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "uuid"
+version = "1.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "value-bag"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,6 +2491,22 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xan-actor"
+version = "9.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78872e176d088706f2ca9ecceb0d660b3d2a8a4564ad0dcd3a211b607451db2"
+dependencies = [
+ "async-trait",
+ "log",
+ "regex",
+ "rmp-serde",
+ "serde",
+ "thiserror",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "xan-log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,5 @@ tokio-tungstenite = "0.23"
 toml = { version = "0.8.8" }
 url = "2.4.1"
 xan-log = "1.2.0"
+xan-actor = "9.0.1"
+async-trait = "0.1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "korea-investment-api"
 authors = ["Xanthorrhizol <xanthorrhizol@proton.me>"]
-version = "3.1.1"
-edition = "2021"
+version = "4.0.0"
+edition = "2024"
 description = "Korea Investment API client for Rust(Not official)"
 repository = "https://github.com/Xanthorrhizol/korea-investment-api"
 readme = "README.md"

--- a/docs/src/api/realtime.md
+++ b/docs/src/api/realtime.md
@@ -25,7 +25,7 @@ pub async fn subscribe_market<T: StreamParser<R> + Send, R: Clone + Send>(
     &mut self,
     tr_key: &str,
     tr_id: TrId,
-) -> Result<(Option<UnboundedReceiver<T>>, SubscribeResponse), Error>
+) -> Result<(Option<broadcast::Receiver<T>>, SubscribeResponse), Error>
 ```
 
 ### 파라미터
@@ -37,16 +37,16 @@ pub async fn subscribe_market<T: StreamParser<R> + Send, R: Clone + Send>(
 
 ### 반환값
 
-- `Option<UnboundedReceiver<T>>`: 새로 생성된 수신 채널. 이미 구독 중이면 `None`
+- `Option<broadcast::Receiver<T>>`: 새로 생성된 수신 채널. 이미 구독 중이면 `None`
 - `SubscribeResponse`: 구독 응답 (성공 여부, 메시지)
 
 ### 예시 — 체결 구독
 
 ```rust
 use korea_investment_api::types::{TrId};
-use korea_investment_api::types::stream::stock::{Exec, ExecRow};
+use korea_investment_api::types::stream::stock::{Exec, exec};
 
-let (rx, response) = api.k_data.subscribe_market::<Exec, ExecRow>(
+let (rx, response) = api.k_data.subscribe_market::<Exec, exec::Body>(
     "005930",
     TrId::RealtimeExecKrx,
 ).await?;
@@ -63,9 +63,9 @@ if let Some(mut rx) = rx {
 ### 예시 — 호가 구독
 
 ```rust
-use korea_investment_api::types::stream::stock::{Ordb, OrdbRow};
+use korea_investment_api::types::stream::stock::{Ordb, ordb};
 
-let (rx, _) = api.k_data.subscribe_market::<Ordb, OrdbRow>(
+let (rx, _) = api.k_data.subscribe_market::<Ordb, ordb::Body>(
     "005930",
     TrId::RealtimeOrdbKrx,
 ).await?;

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -511,7 +511,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(ordb) = rx.recv().await {
+        while let Ok(ordb) = rx.recv().await {
             debug!("[실시간] KRX 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
@@ -538,7 +538,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(exec) = rx.recv().await {
+        while let Ok(exec) = rx.recv().await {
             debug!("[실시간] KRX 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {
@@ -565,7 +565,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(ordb) = rx.recv().await {
+        while let Ok(ordb) = rx.recv().await {
             debug!("[실시간] NXT 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
@@ -592,7 +592,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(exec) = rx.recv().await {
+        while let Ok(exec) = rx.recv().await {
             debug!("[실시간] NXT 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {
@@ -619,7 +619,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(ordb) = rx.recv().await {
+        while let Ok(ordb) = rx.recv().await {
             debug!("[실시간] 통합 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
@@ -645,7 +645,7 @@ async fn main() {
     // 구독한 시세 읽기
     let mut i = 0;
     if let Some(mut rx) = rx {
-        while let Some(exec) = rx.recv().await {
+        while let Ok(exec) = rx.recv().await {
             debug!("[실시간] 통합 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,8 @@ impl KoreaInvestmentApi {
             real_auth.clone(),
         )?;
         let k_data =
-            stock::data::KoreaStockData::new(acc.clone(), auth.clone(), account.clone(), hts_id)?;
+            stock::data::KoreaStockData::new(acc.clone(), auth.clone(), account.clone(), hts_id)
+                .await?;
         info!("API Ready");
         Ok(Self {
             auth,

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -554,7 +554,7 @@ where
         personalseckey: String,
         environment: Environment,
     ) -> DataStreamActor<T, R> {
-        let (ws_stream, _) = connect_async(&url).await.unwrap();
+        let (ws_stream, _) = connect_async(&url).await.expect("Failed to connect");
         let (mut write, mut read) = ws_stream.split();
 
         let (tx, rx) = tokio::sync::broadcast::channel(4096);

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -1,18 +1,19 @@
 use crate::types::request::stock::subscribe::{SubscribeRequest, TrType};
 use crate::types::response::stock::subscribe::SubscribeResponse;
-use crate::types::stream::stock::{MyExec, StreamParser};
+use crate::types::stream::stock::{exec, ordb, Exec, MyExec, Ordb, StreamParser};
 use crate::types::{Account, CustomerType, Environment, TrId};
 use crate::{auth, Error};
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use xan_actor::prelude::*;
 
 type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
 type WsSplitStream = futures_util::stream::SplitStream<WsStream>;
 type _WsSplitSink = futures_util::stream::SplitSink<WsStream, Message>;
 
 #[allow(dead_code)]
-#[derive(Debug)]
 pub struct KoreaStockData {
     krx_exec_url: String,
     krx_ordb_url: String,
@@ -25,13 +26,28 @@ pub struct KoreaStockData {
     auth: auth::Auth,
     account: Account,
     hts_id: String,
+    actor_system: ActorSystem,
     handles: HashMap<(String, TrId), tokio::task::JoinHandle<()>>,
+}
+impl std::fmt::Debug for KoreaStockData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KoreaStockData")
+            .field("krx_exec_url", &self.krx_exec_url)
+            .field("krx_ordb_url", &self.krx_ordb_url)
+            .field("nxt_exec_url", &self.nxt_exec_url)
+            .field("nxt_ordb_url", &self.nxt_ordb_url)
+            .field("union_exec_url", &self.union_exec_url)
+            .field("union_ordb_url", &self.union_ordb_url)
+            .field("my_exec_url", &self.my_exec_url)
+            .field("hts_id", &self.hts_id)
+            .finish()
+    }
 }
 
 impl KoreaStockData {
     /// 국내 주식 실시간 시세에 관한 API
     /// [실시간시세(국내주식)](https://apiportal.koreainvestment.com/apiservice-apiservice?/tryitout/H0STCNT0)
-    pub fn new(
+    pub async fn new(
         environment: Environment,
         auth: auth::Auth,
         account: Account,
@@ -81,6 +97,131 @@ impl KoreaStockData {
             Into::<String>::into(TrId::RealtimeOrdbUnion),
         );
 
+        let app_key = auth.get_appkey();
+        let app_secret = auth.get_appsecret();
+        let personalseckey = auth.get_approval_key().unwrap();
+
+        let mut actor_system = ActorSystem::new(None);
+        let krx_exec_url_data_actor = DataStreamActor::<Exec, exec::Body>::new(
+            krx_exec_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = krx_exec_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register krx_exec_url_data_actor: {}", e);
+        }
+
+        let krx_ordb_url_data_actor = DataStreamActor::<Ordb, ordb::Body>::new(
+            krx_ordb_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = krx_ordb_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register krx_ordb_url_data_actor: {}", e);
+        }
+
+        let nxt_exec_url_data_actor = DataStreamActor::<Exec, exec::Body>::new(
+            nxt_exec_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = nxt_exec_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register nxt_exec_url_data_actor: {}", e);
+        }
+
+        let nxt_ordb_url_data_actor = DataStreamActor::<Ordb, ordb::Body>::new(
+            nxt_ordb_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = nxt_ordb_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register nxt_ordb_url_data_actor: {}", e);
+        }
+
+        let union_exec_url_data_actor = DataStreamActor::<Exec, exec::Body>::new(
+            union_exec_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = union_exec_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register union_exec_url_data_actor: {}", e);
+        }
+
+        let union_ordb_url_data_actor = DataStreamActor::<Ordb, ordb::Body>::new(
+            union_ordb_url.clone(),
+            app_key.clone(),
+            app_secret.clone(),
+            personalseckey.clone(),
+            environment,
+        )
+        .await;
+        if let Err(e) = union_ordb_url_data_actor
+            .register(
+                &mut actor_system,
+                ErrorHandling::Stop,
+                Blocking::Blocking,
+                None,
+            )
+            .await
+        {
+            error!("Failed to register union_ordb_url_data_actor: {}", e);
+        }
+
         Ok(Self {
             krx_exec_url,
             krx_ordb_url,
@@ -92,37 +233,27 @@ impl KoreaStockData {
             environment,
             auth,
             account,
+            actor_system,
             hts_id: hts_id.to_string(),
             handles: HashMap::new(),
         })
     }
 
     /// 종목 시세 구독
-    pub async fn subscribe_market<T: StreamParser<R> + Send, R: Clone + Send>(
+    pub async fn subscribe_market<
+        T: StreamParser<R> + Send + Clone,
+        R: Clone + Send + Sync + 'static,
+    >(
         &mut self,
         tr_key: &str,
         tr_id: TrId,
     ) -> Result<
         (
-            Option<tokio::sync::mpsc::UnboundedReceiver<T>>,
+            Option<tokio::sync::broadcast::Receiver<T>>,
             SubscribeResponse,
         ),
         Error,
     > {
-        let app_key = self.auth.get_appkey();
-        let app_secret = self.auth.get_appsecret();
-        let personalseckey = self.auth.get_approval_key().unwrap();
-        let msg_str = SubscribeRequest::new(
-            app_key,
-            app_secret,
-            personalseckey,
-            CustomerType::Personal,
-            tr_key.to_string(),
-            tr_id.clone(),
-            TrType::Register,
-        )
-        .get_json_string();
-
         let url = match tr_id {
             TrId::RealtimeExecKrx => self.krx_exec_url.clone(),
             TrId::RealtimeOrdbKrx => self.krx_ordb_url.clone(),
@@ -138,47 +269,20 @@ impl KoreaStockData {
             }
         };
 
-        let (ws_stream, _) = connect_async(&url).await?;
-        let (mut write, mut read) = ws_stream.split();
-
-        crate::wait(self.environment).await;
-        write.send(Message::Text(msg_str)).await?;
-        crate::update_last_call();
-
-        let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
-        recv_subscribe_response(&mut read, &mut result).await?;
-
-        let handle_ref = self.handles.get(&(tr_key.to_string(), tr_id));
-        if handle_ref.is_none() || handle_ref.unwrap().is_finished() {
-            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-            let handle = tokio::spawn(async move {
-                loop {
-                    match read.next().await {
-                        Some(Ok(Message::Text(s))) => {
-                            debug!("Get message from stream={:?}", s);
-                            let data = T::parse(s.clone()).expect("Failed to parse message");
-                            if *data.header().tr_id() == TrId::PingPong {
-                                let _ = write.send(Message::Text(s)).await;
-                            } else {
-                                let _ = tx.send(data);
-                            }
-                        }
-                        Some(Ok(_)) => {
-                            error!("Get wrong data from stream");
-                            break;
-                        }
-                        Some(Err(e)) => {
-                            error!("Failed to get message from stream: {:?}", e);
-                            break;
-                        }
-                        None => break,
-                    }
-                }
-            });
-            self.handles.insert((tr_key.to_string(), tr_id), handle);
-            return Ok((Some(rx), result));
+        if let Ok((rx, result)) = self
+            .actor_system
+            .send_and_recv::<DataStreamActor<T, R>>(
+                url,
+                DataStreamCmdMessage::Subscribe(tr_key.to_string(), tr_id),
+            )
+            .await
+        {
+            return Ok((rx, result));
         }
-        Ok((None, result))
+        Ok((
+            None,
+            SubscribeResponse::new(false, "".to_string(), None, None),
+        ))
     }
 
     /// 체결통보 구독
@@ -262,20 +366,6 @@ impl KoreaStockData {
         tr_key: &str,
         tr_id: TrId,
     ) -> Result<SubscribeResponse, Error> {
-        let app_key = self.auth.get_appkey();
-        let app_secret = self.auth.get_appsecret();
-        let personalseckey = self.auth.get_approval_key().unwrap();
-        let msg_str = SubscribeRequest::new(
-            app_key,
-            app_secret,
-            personalseckey,
-            CustomerType::Personal,
-            tr_key.to_string(),
-            tr_id.clone(),
-            TrType::Unregister,
-        )
-        .get_json_string();
-
         let url = match tr_id {
             TrId::RealtimeExecKrx => self.krx_exec_url.clone(),
             TrId::RealtimeOrdbKrx => self.krx_ordb_url.clone(),
@@ -291,20 +381,82 @@ impl KoreaStockData {
             }
         };
 
-        let (ws_stream, _) = connect_async(&url).await?;
-        let (mut write, mut read) = ws_stream.split();
-
-        crate::wait(self.environment).await;
-        write.send(Message::Text(msg_str)).await?;
-        crate::update_last_call();
-
-        let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
-        recv_subscribe_response(&mut read, &mut result).await?;
-
-        if let Some(handle) = self.handles.remove(&(tr_key.to_string(), tr_id)) {
-            handle.abort();
+        match tr_id {
+            TrId::RealtimeExecKrx => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            TrId::RealtimeOrdbKrx => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            TrId::RealtimeExecNxt => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            TrId::RealtimeOrdbNxt => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            TrId::RealtimeExecUnion => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            TrId::RealtimeOrdbUnion => {
+                if let Ok((_rx, result)) = self
+                    .actor_system
+                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
+                        url,
+                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
+                    )
+                    .await
+                {
+                    return Ok(result);
+                }
+            }
+            _ => {}
         }
-        Ok(result)
+        Ok(SubscribeResponse::new(false, "".to_string(), None, None))
     }
 }
 
@@ -369,5 +521,163 @@ impl Drop for KoreaStockData {
                 handle.block_on(self.unsubscribe_market(&tr_key, tr_id))
             });
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum DataStreamCmdMessage {
+    Subscribe(String, TrId), // tr_key, tr_id
+    Unsubscribe(String, TrId),
+}
+
+struct DataStreamActor<T: StreamParser<R> + Send, R: Clone + Send> {
+    url: String,
+    cmd_tx: tokio::sync::mpsc::UnboundedSender<(
+        Arc<DataStreamCmdMessage>,
+        tokio::sync::oneshot::Sender<(
+            Option<tokio::sync::broadcast::Receiver<T>>,
+            SubscribeResponse,
+        )>,
+    )>,
+    _marker: std::marker::PhantomData<R>,
+}
+
+impl<T, R> DataStreamActor<T, R>
+where
+    T: StreamParser<R> + Clone + Send,
+    R: Clone + Send + Sync + 'static,
+{
+    pub async fn new(
+        url: String,
+        app_key: String,
+        app_secret: String,
+        personalseckey: String,
+        environment: Environment,
+    ) -> DataStreamActor<T, R> {
+        let (ws_stream, _) = connect_async(&url).await.unwrap();
+        let (mut write, mut read) = ws_stream.split();
+
+        let (tx, rx) = tokio::sync::broadcast::channel(50);
+        let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<(
+            Arc<DataStreamCmdMessage>,
+            tokio::sync::oneshot::Sender<(
+                Option<tokio::sync::broadcast::Receiver<T>>,
+                SubscribeResponse,
+            )>,
+        )>();
+        let app_key_clone = app_key.clone();
+        let app_secret_clone = app_secret.clone();
+        let personalseckey_clone = personalseckey.clone();
+        let rx_clone = rx.resubscribe();
+        tokio::spawn(async move {
+            let rx = rx_clone;
+            loop {
+                let app_key = app_key_clone.clone();
+                let app_secret = app_secret_clone.clone();
+                let personalseckey = personalseckey_clone.clone();
+                tokio::select! {
+                    msg = read.next() => {
+                        match msg {
+                            Some(Ok(Message::Text(s))) => {
+                                debug!("Get message from stream={:?}", s);
+                                let data = T::parse(s.clone()).expect("Failed to parse message");
+                                if *data.header().tr_id() == TrId::PingPong {
+                                    let _ = write.send(Message::Text(s)).await;
+                                } else {
+                                    let _ = tx.send(data);
+                                }
+                            }
+                            Some(Ok(_)) => {
+                                error!("Get wrong data from stream");
+                                break;
+                            }
+                            Some(Err(e)) => {
+                                error!("Failed to get message from stream: {:?}", e);
+                                break;
+                            }
+                            None => break,
+                        }
+                    }
+                    Some(cmd) = cmd_rx.recv() => {
+                        let msg = cmd.0.as_ref();
+                        let result_tx = cmd.1;
+                        match msg {
+                            DataStreamCmdMessage::Subscribe(tr_key, tr_id) => {
+                                let msg_str = SubscribeRequest::new(
+                                    app_key.clone(),
+                                    app_secret.clone(),
+                                    personalseckey.clone(),
+                                    CustomerType::Personal,
+                                    tr_key.clone(),
+                                    tr_id.clone(),
+                                    TrType::Register,
+                                )
+                                .get_json_string();
+                                crate::wait(environment).await;
+                                let _ = write.send(Message::Text(msg_str)).await;
+                                crate::update_last_call();
+
+                                let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
+                                if let Err(e) = recv_subscribe_response(&mut read, &mut result).await {
+                                    error!("Failed to subscribe: {}", e);
+                                }
+                                result_tx.send((Some(rx.resubscribe()), result)).expect("Failed to send result");
+                            }
+                            DataStreamCmdMessage::Unsubscribe(tr_key, tr_id) => {
+                                let msg_str = SubscribeRequest::new(
+                                    app_key.clone(),
+                                    app_secret.clone(),
+                                    personalseckey.clone(),
+                                    CustomerType::Personal,
+                                    tr_key.clone(),
+                                    tr_id.clone(),
+                                    TrType::Unregister,
+                                )
+                                .get_json_string();
+                                crate::wait(environment).await;
+                                let _ = write.send(Message::Text(msg_str)).await;
+                                crate::update_last_call();
+
+                                let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
+                                if let Err(e) = recv_subscribe_response(&mut read, &mut result).await {
+                                    error!("Failed to unsubscribe: {}", e);
+                                }
+                                result_tx.send((None, result)).expect("Failed to send result");
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        DataStreamActor {
+            url,
+            cmd_tx,
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<T, R> Actor for DataStreamActor<T, R>
+where
+    T: StreamParser<R> + Clone + Send,
+    R: Clone + Sync + Send + 'static,
+{
+    type Message = DataStreamCmdMessage;
+    type Result = (
+        Option<tokio::sync::broadcast::Receiver<T>>,
+        SubscribeResponse,
+    );
+    type Error = Error;
+
+    fn address(&self) -> &str {
+        &self.url
+    }
+
+    async fn handle(&mut self, msg: Arc<Self::Message>) -> Result<Self::Result, Self::Error> {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let _ = self.cmd_tx.send((msg, result_tx));
+        Ok(result_rx.await.expect("Failed to get result"))
     }
 }

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -1,12 +1,12 @@
 use crate::types::request::stock::subscribe::{SubscribeRequest, TrType};
 use crate::types::response::stock::subscribe::SubscribeResponse;
-use crate::types::stream::stock::{exec, ordb, Exec, MyExec, Ordb, StreamParser};
+use crate::types::stream::stock::{Exec, MyExec, Ordb, StreamParser, exec, ordb};
 use crate::types::{Account, CustomerType, Environment, TrId};
-use crate::{auth, Error};
+use crate::{Error, auth};
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 use xan_actor::prelude::*;
 
 type WsStream = WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
@@ -265,7 +265,7 @@ impl KoreaStockData {
                 return Err(Error::WrongTrId(
                     tr_id,
                     "RealtimeExecXXX or RealtimeOrdbXXX",
-                ))
+                ));
             }
         };
 
@@ -377,7 +377,7 @@ impl KoreaStockData {
                 return Err(Error::WrongTrId(
                     tr_id,
                     "RealtimeExecXXX or RealtimeOrdbXXX",
-                ))
+                ));
             }
         };
 
@@ -557,7 +557,7 @@ where
         let (ws_stream, _) = connect_async(&url).await.unwrap();
         let (mut write, mut read) = ws_stream.split();
 
-        let (tx, rx) = tokio::sync::broadcast::channel(50);
+        let (tx, rx) = tokio::sync::broadcast::channel(4096);
         let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<(
             Arc<DataStreamCmdMessage>,
             tokio::sync::oneshot::Sender<(


### PR DESCRIPTION
종목 구독 시 연결을 새로 하게 되면서 기존 구독이 날아가는 현상이 있었습니다.
endpoint들 모두와 연결을 미리 성사시켜 둔 후, 구독 및 구독취소 요청을 주고받는 방식으로 변경했습니다. 이로 인해 여러 종목을 동시에 수신할 수 있게 되었습니다.
고치는 과정에서 xan-actor를 이용하게 되었습니다.