### PR TITLE
refactor: deduplicate unsubscribe_market() and extract market_url() helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "korea-investment-api"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "aes",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "korea-investment-api"
 authors = ["Xanthorrhizol <xanthorrhizol@proton.me>"]
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 description = "Korea Investment API client for Rust(Not official)"
 repository = "https://github.com/Xanthorrhizol/korea-investment-api"

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -239,22 +239,6 @@ impl KoreaStockData {
         })
     }
 
-    /// TrId로부터 해당 WebSocket endpoint URL을 반환하는 헬퍼 메서드
-    fn market_url(&self, tr_id: &TrId) -> Result<String, Error> {
-        match tr_id {
-            TrId::RealtimeExecKrx => Ok(self.krx_exec_url.clone()),
-            TrId::RealtimeOrdbKrx => Ok(self.krx_ordb_url.clone()),
-            TrId::RealtimeExecNxt => Ok(self.nxt_exec_url.clone()),
-            TrId::RealtimeOrdbNxt => Ok(self.nxt_ordb_url.clone()),
-            TrId::RealtimeExecUnion => Ok(self.union_exec_url.clone()),
-            TrId::RealtimeOrdbUnion => Ok(self.union_ordb_url.clone()),
-            _ => Err(Error::WrongTrId(
-                tr_id.clone(),
-                "RealtimeExecXXX or RealtimeOrdbXXX",
-            )),
-        }
-    }
-
     /// 종목 시세 구독
     pub async fn subscribe_market<
         T: StreamParser<R> + Send + Clone,
@@ -373,24 +357,38 @@ impl KoreaStockData {
         let cmd = DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id.clone());
 
         let result = match tr_id {
-            TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => {
-                self.actor_system
-                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(url, cmd)
-                    .await
-                    .ok()
-                    .map(|(_rx, r)| r)
-            }
-            TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => {
-                self.actor_system
-                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
-                    .await
-                    .ok()
-                    .map(|(_rx, r)| r)
-            }
+            TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => self
+                .actor_system
+                .send_and_recv::<DataStreamActor<Exec, exec::Body>>(url, cmd)
+                .await
+                .ok()
+                .map(|(_rx, r)| r),
+            TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => self
+                .actor_system
+                .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
+                .await
+                .ok()
+                .map(|(_rx, r)| r),
             _ => None,
         };
 
         Ok(result.unwrap_or_else(|| SubscribeResponse::new(false, "".to_string(), None, None)))
+    }
+
+    /// TrId로부터 해당 WebSocket endpoint URL을 반환하는 헬퍼 메서드
+    fn market_url(&self, tr_id: &TrId) -> Result<String, Error> {
+        match tr_id {
+            TrId::RealtimeExecKrx => Ok(self.krx_exec_url.clone()),
+            TrId::RealtimeOrdbKrx => Ok(self.krx_ordb_url.clone()),
+            TrId::RealtimeExecNxt => Ok(self.nxt_exec_url.clone()),
+            TrId::RealtimeOrdbNxt => Ok(self.nxt_ordb_url.clone()),
+            TrId::RealtimeExecUnion => Ok(self.union_exec_url.clone()),
+            TrId::RealtimeOrdbUnion => Ok(self.union_ordb_url.clone()),
+            _ => Err(Error::WrongTrId(
+                tr_id.clone(),
+                "RealtimeExecXXX or RealtimeOrdbXXX",
+            )),
+        }
     }
 }
 

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -239,6 +239,22 @@ impl KoreaStockData {
         })
     }
 
+    /// TrId로부터 해당 WebSocket endpoint URL을 반환하는 헬퍼 메서드
+    fn market_url(&self, tr_id: &TrId) -> Result<String, Error> {
+        match tr_id {
+            TrId::RealtimeExecKrx => Ok(self.krx_exec_url.clone()),
+            TrId::RealtimeOrdbKrx => Ok(self.krx_ordb_url.clone()),
+            TrId::RealtimeExecNxt => Ok(self.nxt_exec_url.clone()),
+            TrId::RealtimeOrdbNxt => Ok(self.nxt_ordb_url.clone()),
+            TrId::RealtimeExecUnion => Ok(self.union_exec_url.clone()),
+            TrId::RealtimeOrdbUnion => Ok(self.union_ordb_url.clone()),
+            _ => Err(Error::WrongTrId(
+                tr_id.clone(),
+                "RealtimeExecXXX or RealtimeOrdbXXX",
+            )),
+        }
+    }
+
     /// 종목 시세 구독
     pub async fn subscribe_market<
         T: StreamParser<R> + Send + Clone,
@@ -254,20 +270,7 @@ impl KoreaStockData {
         ),
         Error,
     > {
-        let url = match tr_id {
-            TrId::RealtimeExecKrx => self.krx_exec_url.clone(),
-            TrId::RealtimeOrdbKrx => self.krx_ordb_url.clone(),
-            TrId::RealtimeExecNxt => self.nxt_exec_url.clone(),
-            TrId::RealtimeOrdbNxt => self.nxt_ordb_url.clone(),
-            TrId::RealtimeExecUnion => self.union_exec_url.clone(),
-            TrId::RealtimeOrdbUnion => self.union_ordb_url.clone(),
-            _ => {
-                return Err(Error::WrongTrId(
-                    tr_id,
-                    "RealtimeExecXXX or RealtimeOrdbXXX",
-                ));
-            }
-        };
+        let url = self.market_url(&tr_id)?;
 
         if let Ok((rx, result)) = self
             .actor_system
@@ -366,97 +369,28 @@ impl KoreaStockData {
         tr_key: &str,
         tr_id: TrId,
     ) -> Result<SubscribeResponse, Error> {
-        let url = match tr_id {
-            TrId::RealtimeExecKrx => self.krx_exec_url.clone(),
-            TrId::RealtimeOrdbKrx => self.krx_ordb_url.clone(),
-            TrId::RealtimeExecNxt => self.nxt_exec_url.clone(),
-            TrId::RealtimeOrdbNxt => self.nxt_ordb_url.clone(),
-            TrId::RealtimeExecUnion => self.union_exec_url.clone(),
-            TrId::RealtimeOrdbUnion => self.union_ordb_url.clone(),
-            _ => {
-                return Err(Error::WrongTrId(
-                    tr_id,
-                    "RealtimeExecXXX or RealtimeOrdbXXX",
-                ));
+        let url = self.market_url(&tr_id)?;
+        let cmd = DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id.clone());
+
+        let result = match tr_id {
+            TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => {
+                self.actor_system
+                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(url, cmd)
+                    .await
+                    .ok()
+                    .map(|(_rx, r)| r)
             }
+            TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => {
+                self.actor_system
+                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
+                    .await
+                    .ok()
+                    .map(|(_rx, r)| r)
+            }
+            _ => None,
         };
 
-        match tr_id {
-            TrId::RealtimeExecKrx => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            TrId::RealtimeOrdbKrx => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            TrId::RealtimeExecNxt => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            TrId::RealtimeOrdbNxt => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            TrId::RealtimeExecUnion => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            TrId::RealtimeOrdbUnion => {
-                if let Ok((_rx, result)) = self
-                    .actor_system
-                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(
-                        url,
-                        DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id),
-                    )
-                    .await
-                {
-                    return Ok(result);
-                }
-            }
-            _ => {}
-        }
-        Ok(SubscribeResponse::new(false, "".to_string(), None, None))
+        Ok(result.unwrap_or_else(|| SubscribeResponse::new(false, "".to_string(), None, None)))
     }
 }
 


### PR DESCRIPTION
## 변경 사항

PR #16 리뷰 코멘트(unsubscribe_market() 중복 코드) 해결

### market_url() 헬퍼 메서드 추출

`TrId` → WebSocket endpoint URL 매핑을 별도 메서드로 분리하여
`subscribe_market()`과 `unsubscribe_market()` 양쪽에서 재사용합니다.

```rust
fn market_url(&self, tr_id: &TrId) -> Result<String, Error>
```

### unsubscribe_market() 6개 arm → 2개 arm

**Before:** `RealtimeExecKrx`, `RealtimeOrdbKrx`, `RealtimeExecNxt`, `RealtimeOrdbNxt`, `RealtimeExecUnion`, `RealtimeOrdbUnion` 각각 개별 처리

**After:** Exec 계열과 Ordb 계열을 `|` 패턴으로 묶어 2개 arm으로 처리

```rust
TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => { ... }
TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => { ... }
```

### 변경 규모
- +34 / -100 lines