### PR TITLE
실시간 시세 여러 종목 수신 가능케 하기

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,8 @@ pub enum Error {
     TomlSerializeError(#[from] toml::ser::Error),
     #[error(transparent)]
     IoError(#[from] std::io::Error),
+    #[error(transparent)]
+    ActorError(#[from] xan_actor::ActorError),
     // custom
     #[error("Auth init failed - None value in {0}")]
     AuthInitFailed(&'static str),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,8 @@ pub enum Error {
     IoError(#[from] std::io::Error),
     #[error(transparent)]
     ActorError(#[from] xan_actor::ActorError),
+    #[error(transparent)]
+    OneshotRecvError(#[from] tokio::sync::oneshot::error::RecvError),
     // custom
     #[error("Auth init failed - None value in {0}")]
     AuthInitFailed(&'static str),

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -509,7 +509,7 @@ impl Drop for KoreaStockData {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 enum DataStreamCmdMessage {
     Subscribe(String, TrId), // tr_key, tr_id
     Unsubscribe(String, TrId),
@@ -557,7 +557,7 @@ where
         tokio::spawn(async move {
             let rx = rx_clone;
             let mut result_tx_map: HashMap<
-                (TrId, String),
+                DataStreamCmdMessage,
                 tokio::sync::oneshot::Sender<(
                     Option<tokio::sync::broadcast::Receiver<T>>,
                     SubscribeResponse,
@@ -575,7 +575,19 @@ where
                                 if let Ok(j) = json::parse(&s) {
                                     match parse_subscribe_response(&j) {
                                         Ok(Some(result)) => {
-                                            if let Some(result_tx) = result_tx_map.remove(&(result.tr_id().clone(), result.tr_key().clone())) {
+                                            let map_key = match result.msg().as_str() {
+                                                "SUBSCRIBE SUCCESS" => {
+                                                    DataStreamCmdMessage::Subscribe(result.tr_key().clone(), result.tr_id().clone())
+                                                }
+                                                "UNSUBSCRIBE SUCCESS" => {
+                                                    DataStreamCmdMessage::Unsubscribe(result.tr_key().clone(), result.tr_id().clone())
+                                                }
+                                                msg => {
+                                                    error!("Failed to parse subscribe response: msg={}", msg);
+                                                    continue;
+                                                }
+                                            };
+                                            if let Some(result_tx) = result_tx_map.remove(&map_key) {
                                                 if let Err(e) = result_tx.send((Some(rx.resubscribe()), result)) {
                                                     error!("Failed to send result: {:?}", e);
                                                 }
@@ -629,7 +641,7 @@ where
                                     TrType::Register,
                                 )
                                 .get_json_string();
-                                result_tx_map.insert((tr_id.clone(), tr_key.clone()), result_tx);
+                                result_tx_map.insert(DataStreamCmdMessage::Subscribe(tr_key.clone(), tr_id.clone()), result_tx);
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();
@@ -645,7 +657,7 @@ where
                                     TrType::Unregister,
                                 )
                                 .get_json_string();
-                                result_tx_map.insert((tr_id.clone(), tr_key.clone()), result_tx);
+                                result_tx_map.insert(DataStreamCmdMessage::Unsubscribe(tr_key.clone(), tr_id.clone()), result_tx);
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -393,7 +393,7 @@ impl KoreaStockData {
     }
 }
 
-async fn parse_subscribe_response(
+fn parse_subscribe_response(
     msg: &json::JsonValue,
 ) -> Result<Option<SubscribeResponse>, json::Error> {
     let mut result = SubscribeResponse::new(
@@ -461,7 +461,7 @@ async fn recv_subscribe_response(
         match msg {
             Ok(Message::Text(s)) => {
                 let json_value = json::parse(&s)?;
-                match parse_subscribe_response(&json_value).await {
+                match parse_subscribe_response(&json_value) {
                     Ok(Some(result)) => {
                         return Ok(result);
                     }
@@ -570,7 +570,7 @@ where
                             Some(Ok(Message::Text(s))) => {
                                 debug!("Get message from stream={:?}", s);
                                 if let Ok(j) = json::parse(&s) {
-                                    match parse_subscribe_response(&j).await {
+                                    match parse_subscribe_response(&j) {
                                         Ok(Some(result)) => {
                                             let result_tx = result_tx_map.remove(result.tr_key()).expect("Failed to get result tx");
                                             result_tx.send((Some(rx.resubscribe()), result)).expect("Failed to send result");

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -319,6 +319,8 @@ impl KoreaStockData {
 
         if let Some(handle) = self.handles.remove(&(String::default(), tr_id)) {
             handle.abort();
+        } else {
+            error!("Failed to remove handle");
         }
 
         let (iv, key) = (
@@ -572,8 +574,13 @@ where
                                 if let Ok(j) = json::parse(&s) {
                                     match parse_subscribe_response(&j) {
                                         Ok(Some(result)) => {
-                                            let result_tx = result_tx_map.remove(result.tr_key()).expect("Failed to get result tx");
-                                            result_tx.send((Some(rx.resubscribe()), result)).expect("Failed to send result");
+                                            if let Some(result_tx) = result_tx_map.remove(result.tr_key()) {
+                                                if let Err(e) = result_tx.send((Some(rx.resubscribe()), result)) {
+                                                    error!("Failed to send result: {:?}", e);
+                                                }
+                                            } else {
+                                                error!("Failed to send result");
+                                            }
                                         }
                                         Err(e) => {
                                             error!("Failed to parse subscribe response: {}", e);

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -696,6 +696,13 @@ where
     async fn handle(&mut self, msg: Arc<Self::Message>) -> Result<Self::Result, Self::Error> {
         let (result_tx, result_rx) = tokio::sync::oneshot::channel();
         let _ = self.cmd_tx.send((msg, result_tx));
-        Ok(result_rx.await.expect("Failed to get result"))
+        let result = match result_rx.await {
+            Ok(result) => result,
+            Err(e) => {
+                error!("Failed to get result: {}", e);
+                return Err(e.into());
+            }
+        };
+        Ok(result)
     }
 }

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -364,13 +364,13 @@ impl KoreaStockData {
         match tr_id {
             TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => {
                 self.actor_system
-                    .send::<DataStreamActor<Exec, exec::Body>>(url, cmd)
-                    .await?
+                    .send_and_recv::<DataStreamActor<Exec, exec::Body>>(url, cmd)
+                    .await?;
             }
             TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => {
                 self.actor_system
-                    .send::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
-                    .await?
+                    .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
+                    .await?;
             }
             _ => {}
         }
@@ -413,7 +413,15 @@ fn parse_subscribe_response(
                     if let Some(result_tr) = o.get("tr_id") {
                         if &result_tr.to_string() == "PINGPONG" {
                             return Ok(None);
+                        } else {
+                            result.set_tr_id(
+                                TrId::from_str(&result_tr.to_string())
+                                    .expect("Failed to parse tr_id"),
+                            );
                         }
+                    }
+                    if let Some(s) = o.get("tr_key") {
+                        result.set_tr_key(s.to_string());
                     }
                 }
             }
@@ -426,16 +434,6 @@ fn parse_subscribe_response(
                                 result.set_success(true);
                             }
                             result.set_msg(s);
-                        }
-                        if let Some(json::JsonValue::Object(o)) = o.get("header") {
-                            if let Some(s) = o.get("tr_id") {
-                                result.set_tr_id(
-                                    TrId::from_str(&s.to_string()).expect("Failed to parse tr_id"),
-                                );
-                            }
-                            if let Some(s) = o.get("tr_key") {
-                                result.set_tr_key(s.to_string());
-                            }
                         }
                         if let Some(json::JsonValue::Object(o)) = o.get("output") {
                             if let Some(s) = o.get("iv") {
@@ -556,7 +554,7 @@ where
         tokio::spawn(async move {
             let rx = rx_clone;
             let mut result_tx_map: HashMap<
-                String,
+                (TrId, String),
                 tokio::sync::oneshot::Sender<(
                     Option<tokio::sync::broadcast::Receiver<T>>,
                     SubscribeResponse,
@@ -574,7 +572,7 @@ where
                                 if let Ok(j) = json::parse(&s) {
                                     match parse_subscribe_response(&j) {
                                         Ok(Some(result)) => {
-                                            if let Some(result_tx) = result_tx_map.remove(result.tr_key()) {
+                                            if let Some(result_tx) = result_tx_map.remove(&(result.tr_id().clone(), result.tr_key().clone())) {
                                                 if let Err(e) = result_tx.send((Some(rx.resubscribe()), result)) {
                                                     error!("Failed to send result: {:?}", e);
                                                 }
@@ -622,10 +620,10 @@ where
                                     TrType::Register,
                                 )
                                 .get_json_string();
+                                result_tx_map.insert((tr_id.clone(), tr_key.clone()), result_tx);
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();
-                                result_tx_map.insert(tr_key.clone(), result_tx);
                             }
                             DataStreamCmdMessage::Unsubscribe(tr_key, tr_id) => {
                                 let msg_str = SubscribeRequest::new(
@@ -638,6 +636,7 @@ where
                                     TrType::Unregister,
                                 )
                                 .get_json_string();
+                                result_tx_map.insert((tr_id.clone(), tr_key.clone()), result_tx);
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -5,6 +5,7 @@ use crate::types::{Account, CustomerType, Environment, TrId};
 use crate::{Error, auth};
 use futures_util::{SinkExt, StreamExt};
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::Arc;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async, tungstenite::Message};
 use xan_actor::prelude::*;
@@ -268,7 +269,14 @@ impl KoreaStockData {
         }
         Ok((
             None,
-            SubscribeResponse::new(false, "".to_string(), None, None),
+            SubscribeResponse::new(
+                false,
+                TrId::PingPong,
+                "".to_string(),
+                "".to_string(),
+                None,
+                None,
+            ),
         ))
     }
 
@@ -307,8 +315,7 @@ impl KoreaStockData {
         write.send(Message::Text(msg_str)).await?;
         crate::update_last_call();
 
-        let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
-        recv_subscribe_response(&mut read, &mut result).await?;
+        let result = recv_subscribe_response(tr_id.clone(), &mut read).await?;
 
         if let Some(handle) = self.handles.remove(&(String::default(), tr_id)) {
             handle.abort();
@@ -348,31 +355,25 @@ impl KoreaStockData {
     }
 
     /// 종목 시세 구독 해체
-    pub async fn unsubscribe_market(
-        &mut self,
-        tr_key: &str,
-        tr_id: TrId,
-    ) -> Result<SubscribeResponse, Error> {
+    pub async fn unsubscribe_market(&mut self, tr_key: &str, tr_id: TrId) -> Result<(), Error> {
         let url = self.market_url(&tr_id)?;
         let cmd = DataStreamCmdMessage::Unsubscribe(tr_key.to_string(), tr_id.clone());
 
-        let result = match tr_id {
-            TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => self
-                .actor_system
-                .send_and_recv::<DataStreamActor<Exec, exec::Body>>(url, cmd)
-                .await
-                .ok()
-                .map(|(_rx, r)| r),
-            TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => self
-                .actor_system
-                .send_and_recv::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
-                .await
-                .ok()
-                .map(|(_rx, r)| r),
-            _ => None,
-        };
+        match tr_id {
+            TrId::RealtimeExecKrx | TrId::RealtimeExecNxt | TrId::RealtimeExecUnion => {
+                self.actor_system
+                    .send::<DataStreamActor<Exec, exec::Body>>(url, cmd)
+                    .await?
+            }
+            TrId::RealtimeOrdbKrx | TrId::RealtimeOrdbNxt | TrId::RealtimeOrdbUnion => {
+                self.actor_system
+                    .send::<DataStreamActor<Ordb, ordb::Body>>(url, cmd)
+                    .await?
+            }
+            _ => {}
+        }
 
-        Ok(result.unwrap_or_else(|| SubscribeResponse::new(false, "".to_string(), None, None)))
+        Ok(())
     }
 
     /// TrId로부터 해당 WebSocket endpoint URL을 반환하는 헬퍼 메서드
@@ -392,56 +393,105 @@ impl KoreaStockData {
     }
 }
 
-async fn recv_subscribe_response(
-    read: &mut WsSplitStream,
-    result: &mut SubscribeResponse,
-) -> Result<(), json::Error> {
-    while let Some(msg) = read.next().await {
-        match msg {
-            Ok(Message::Text(s)) => {
-                let json_value = json::parse(&s)?;
-                match json_value {
-                    json::JsonValue::Object(obj) => {
-                        if let Some(header) = obj.get("header") {
-                            if let json::JsonValue::Object(o) = header {
-                                if let Some(result_tr) = o.get("tr_id") {
-                                    if &result_tr.to_string() == "PINGPONG" {
-                                        continue;
-                                    }
-                                }
+async fn parse_subscribe_response(
+    msg: &json::JsonValue,
+) -> Result<Option<SubscribeResponse>, json::Error> {
+    let mut result = SubscribeResponse::new(
+        false,
+        TrId::PingPong,
+        "".to_string(),
+        "".to_string(),
+        None,
+        None,
+    );
+    match msg {
+        json::JsonValue::Object(obj) => {
+            if let Some(header) = obj.get("header") {
+                if let json::JsonValue::Object(o) = header {
+                    if let Some(result_tr) = o.get("tr_id") {
+                        if &result_tr.to_string() == "PINGPONG" {
+                            return Ok(None);
+                        }
+                    }
+                }
+            }
+            if let Some(v) = obj.get("body") {
+                match v {
+                    json::JsonValue::Object(o) => {
+                        if let Some(s) = o.get("msg1") {
+                            let s = s.to_string();
+                            if &s == "SUBSCRIBE SUCCESS" {
+                                result.set_success(true);
+                            }
+                            result.set_msg(s);
+                        }
+                        if let Some(json::JsonValue::Object(o)) = o.get("header") {
+                            if let Some(s) = o.get("tr_id") {
+                                result.set_tr_id(
+                                    TrId::from_str(&s.to_string()).expect("Failed to parse tr_id"),
+                                );
+                            }
+                            if let Some(s) = o.get("tr_key") {
+                                result.set_tr_key(s.to_string());
                             }
                         }
-                        if let Some(v) = obj.get("body") {
-                            match v {
-                                json::JsonValue::Object(o) => {
-                                    if let Some(s) = o.get("msg1") {
-                                        let s = s.to_string();
-                                        if &s == "SUBSCRIBE SUCCESS" {
-                                            result.set_success(true);
-                                        }
-                                        result.set_msg(s);
-                                    }
-                                    if let Some(json::JsonValue::Object(o)) = o.get("output") {
-                                        if let Some(s) = o.get("iv") {
-                                            result.set_iv(Some(s.to_string()));
-                                        }
-                                        if let Some(s) = o.get("key") {
-                                            result.set_key(Some(s.to_string()));
-                                        }
-                                    }
-                                }
-                                _ => {}
+                        if let Some(json::JsonValue::Object(o)) = o.get("output") {
+                            if let Some(s) = o.get("iv") {
+                                result.set_iv(Some(s.to_string()));
+                            }
+                            if let Some(s) = o.get("key") {
+                                result.set_key(Some(s.to_string()));
                             }
                         }
                     }
                     _ => {}
                 }
             }
+        }
+        _ => {}
+    }
+    Ok(Some(result))
+}
+
+async fn recv_subscribe_response(
+    tr_id: TrId,
+    read: &mut WsSplitStream,
+) -> Result<SubscribeResponse, json::Error> {
+    while let Some(msg) = read.next().await {
+        match msg {
+            Ok(Message::Text(s)) => {
+                let json_value = json::parse(&s)?;
+                match parse_subscribe_response(&json_value).await {
+                    Ok(Some(result)) => {
+                        return Ok(result);
+                    }
+                    Err(e) => {
+                        error!("Failed to parse subscribe response: {}", e);
+                        return Ok(SubscribeResponse::new(
+                            false,
+                            tr_id,
+                            "".to_string(),
+                            "".to_string(),
+                            None,
+                            None,
+                        ));
+                    }
+                    _ => {
+                        // pingpong
+                    }
+                }
+            }
             _ => {}
         }
-        break;
     }
-    Ok(())
+    Ok(SubscribeResponse::new(
+        false,
+        tr_id,
+        "".to_string(),
+        "".to_string(),
+        None,
+        None,
+    ))
 }
 
 impl Drop for KoreaStockData {
@@ -503,6 +553,13 @@ where
         let rx_clone = rx.resubscribe();
         tokio::spawn(async move {
             let rx = rx_clone;
+            let mut result_tx_map: HashMap<
+                String,
+                tokio::sync::oneshot::Sender<(
+                    Option<tokio::sync::broadcast::Receiver<T>>,
+                    SubscribeResponse,
+                )>,
+            > = HashMap::new();
             loop {
                 let app_key = app_key_clone.clone();
                 let app_secret = app_secret_clone.clone();
@@ -512,11 +569,24 @@ where
                         match msg {
                             Some(Ok(Message::Text(s))) => {
                                 debug!("Get message from stream={:?}", s);
-                                let data = T::parse(s.clone()).expect("Failed to parse message");
-                                if *data.header().tr_id() == TrId::PingPong {
-                                    let _ = write.send(Message::Text(s)).await;
+                                if let Ok(j) = json::parse(&s) {
+                                    match parse_subscribe_response(&j).await {
+                                        Ok(Some(result)) => {
+                                            let result_tx = result_tx_map.remove(result.tr_key()).expect("Failed to get result tx");
+                                            result_tx.send((Some(rx.resubscribe()), result)).expect("Failed to send result");
+                                        }
+                                        Err(e) => {
+                                            error!("Failed to parse subscribe response: {}", e);
+                                        }
+                                        _ => {}
+                                    }
                                 } else {
-                                    let _ = tx.send(data);
+                                    let data = T::parse(s.clone()).expect("Failed to parse message");
+                                    if *data.header().tr_id() == TrId::PingPong {
+                                        let _ = write.send(Message::Text(s)).await;
+                                    } else {
+                                        let _ = tx.send(data);
+                                    }
                                 }
                             }
                             Some(Ok(_)) => {
@@ -548,12 +618,7 @@ where
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();
-
-                                let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
-                                if let Err(e) = recv_subscribe_response(&mut read, &mut result).await {
-                                    error!("Failed to subscribe: {}", e);
-                                }
-                                result_tx.send((Some(rx.resubscribe()), result)).expect("Failed to send result");
+                                result_tx_map.insert(tr_key.clone(), result_tx);
                             }
                             DataStreamCmdMessage::Unsubscribe(tr_key, tr_id) => {
                                 let msg_str = SubscribeRequest::new(
@@ -569,12 +634,6 @@ where
                                 crate::wait(environment).await;
                                 let _ = write.send(Message::Text(msg_str)).await;
                                 crate::update_last_call();
-
-                                let mut result = SubscribeResponse::new(false, "".to_string(), None, None);
-                                if let Err(e) = recv_subscribe_response(&mut read, &mut result).await {
-                                    error!("Failed to unsubscribe: {}", e);
-                                }
-                                result_tx.send((None, result)).expect("Failed to send result");
                             }
                         }
                     }

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -331,8 +331,13 @@ impl KoreaStockData {
             loop {
                 match read.next().await {
                     Some(Ok(Message::Text(s))) => {
-                        let data = MyExec::parse(s.clone(), iv.clone(), key.clone())
-                            .expect("Failed to parse message");
+                        let data = match MyExec::parse(s.clone(), iv.clone(), key.clone()) {
+                            Ok(data) => data,
+                            Err(e) => {
+                                error!("Failed to parse message: {}", e);
+                                break;
+                            }
+                        };
                         if data.header().tr_id() == &TrId::PingPong {
                             let _ = write.send(Message::Text(s)).await;
                         } else {
@@ -605,7 +610,7 @@ where
                                         Ok(data) => data,
                                         Err(e) => {
                                             error!("Failed to parse message: {}", e);
-                                            continue;
+                                            break;
                                         }
                                     };
                                     if *data.header().tr_id() == TrId::PingPong {

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -318,9 +318,8 @@ impl KoreaStockData {
         let result = recv_subscribe_response(tr_id.clone(), &mut read).await?;
 
         if let Some(handle) = self.handles.remove(&(String::default(), tr_id)) {
+            warn!("Aborting old handle");
             handle.abort();
-        } else {
-            error!("Failed to remove handle");
         }
 
         let (iv, key) = (
@@ -414,10 +413,14 @@ fn parse_subscribe_response(
                         if &result_tr.to_string() == "PINGPONG" {
                             return Ok(None);
                         } else {
-                            result.set_tr_id(
-                                TrId::from_str(&result_tr.to_string())
-                                    .expect("Failed to parse tr_id"),
-                            );
+                            let tr_id = match TrId::from_str(&result_tr.to_string()) {
+                                Ok(tr_id) => tr_id,
+                                Err(e) => {
+                                    error!("Failed to parse tr_id: {}", e);
+                                    return Ok(None);
+                                }
+                            };
+                            result.set_tr_id(tr_id);
                         }
                     }
                     if let Some(s) = o.get("tr_key") {
@@ -586,7 +589,13 @@ where
                                         _ => {}
                                     }
                                 } else {
-                                    let data = T::parse(s.clone()).expect("Failed to parse message");
+                                    let data = match T::parse(s.clone()) {
+                                        Ok(data) => data,
+                                        Err(e) => {
+                                            error!("Failed to parse message: {}", e);
+                                            continue;
+                                        }
+                                    };
                                     if *data.header().tr_id() == TrId::PingPong {
                                         let _ = write.send(Message::Text(s)).await;
                                     } else {

--- a/src/types/response/stock/subscribe.rs
+++ b/src/types/response/stock/subscribe.rs
@@ -7,6 +7,10 @@ pub struct SubscribeResponse {
     #[getset(get = "pub", set = "pub")]
     success: bool,
     #[getset(get = "pub", set = "pub")]
+    tr_id: TrId,
+    #[getset(get = "pub", set = "pub")]
+    tr_key: String,
+    #[getset(get = "pub", set = "pub")]
     msg: String,
     #[getset(get = "pub", set = "pub")]
     iv: Option<String>,
@@ -15,9 +19,18 @@ pub struct SubscribeResponse {
 }
 
 impl SubscribeResponse {
-    pub fn new(success: bool, msg: String, iv: Option<String>, key: Option<String>) -> Self {
+    pub fn new(
+        success: bool,
+        tr_id: TrId,
+        tr_key: String,
+        msg: String,
+        iv: Option<String>,
+        key: Option<String>,
+    ) -> Self {
         Self {
             success,
+            tr_id,
+            tr_key,
             msg,
             iv,
             key,

--- a/src/types/stream/stock/exec.rs
+++ b/src/types/stream/stock/exec.rs
@@ -129,6 +129,7 @@ impl StreamParser<Body> for Exec {
                     }
                     bodies
                 } else {
+                    error!("Invalid data: {}", s);
                     Vec::new()
                 }
             };

--- a/src/types/stream/stock/mod.rs
+++ b/src/types/stream/stock/mod.rs
@@ -41,7 +41,7 @@ where
             TrId::RealtimeOrdbNxt => 65,
             TrId::RealtimeExecUnion => 46,
             TrId::RealtimeOrdbUnion => 65,
-            _ => 0,
+            _ => unreachable!(),
         }
     }
 }

--- a/src/types/stream/stock/ordb.rs
+++ b/src/types/stream/stock/ordb.rs
@@ -161,6 +161,7 @@ impl StreamParser<Body> for Ordb {
                     }
                     bodies
                 } else {
+                    error!("invalid data: {}", s);
                     Vec::new()
                 }
             };


### PR DESCRIPTION
실시간 시세 수신 시 여러 종목을 수신하는 경우 기존 수신이 끊겨 버리는 버그가 있었습니다.
여러 종목을 수신하더라도 연결이 끊기지 않도록 하였습니다.