### PR TITLE
F: use try_current() in Drop to avoid panic when no runtime

### DIFF
--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -505,7 +505,9 @@ async fn recv_subscribe_response(
 impl Drop for KoreaStockData {
     fn drop(&mut self) {
         let keys: Vec<_> = self.handles.keys().cloned().collect();
-        let handle = tokio::runtime::Handle::current();
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
         for (tr_key, tr_id) in keys {
             let _ = tokio::task::block_in_place(|| {
                 handle.block_on(self.unsubscribe_market(&tr_key, tr_id))


### PR DESCRIPTION
## 변경 사항

`Drop` 구현에서 `Handle::current()` → `Handle::try_current()`로 교체.

## 문제

`Handle::current()`는 tokio 런타임 컨텍스트 밖에서 호출되면 패닉한다. `KoreaStockData`가 런타임 외부에서 drop될 경우 패닉이 발생할 수 있었다.

## 수정

`try_current()`는 런타임이 없으면 `Err`를 반환한다. 런타임이 없는 경우 unsubscribe를 건너뛰고 정상 종료한다.

```rust
// Before
let handle = tokio::runtime::Handle::current(); // panics if no runtime

// After
let Ok(handle) = tokio::runtime::Handle::try_current() else {
    return;
};
```