### PR TITLE
R: fix log levels across data stream and stream types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,7 +865,7 @@ checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "korea-investment-api"
-version = "5.0.1"
+version = "5.0.2"
 dependencies = [
  "aes",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "korea-investment-api"
 authors = ["Xanthorrhizol <xanthorrhizol@proton.me>"]
-version = "5.0.1"
+version = "5.0.2"
 edition = "2024"
 description = "Korea Investment API client for Rust(Not official)"
 repository = "https://github.com/Xanthorrhizol/korea-investment-api"

--- a/src/bin/example.rs
+++ b/src/bin/example.rs
@@ -512,7 +512,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(ordb) = rx.recv().await {
-            debug!("[실시간] KRX 호가 수신: {:?}", ordb);
+            trace!("[실시간] KRX 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
                 break;
@@ -539,7 +539,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(exec) = rx.recv().await {
-            debug!("[실시간] KRX 체결 수신: {:?}", exec);
+            trace!("[실시간] KRX 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {
                 break;
@@ -566,7 +566,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(ordb) = rx.recv().await {
-            debug!("[실시간] NXT 호가 수신: {:?}", ordb);
+            trace!("[실시간] NXT 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
                 break;
@@ -593,7 +593,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(exec) = rx.recv().await {
-            debug!("[실시간] NXT 체결 수신: {:?}", exec);
+            trace!("[실시간] NXT 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {
                 break;
@@ -620,7 +620,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(ordb) = rx.recv().await {
-            debug!("[실시간] 통합 호가 수신: {:?}", ordb);
+            trace!("[실시간] 통합 호가 수신: {:?}", ordb);
             i += 1;
             if i == 10 {
                 break;
@@ -646,7 +646,7 @@ async fn main() {
     let mut i = 0;
     if let Some(mut rx) = rx {
         while let Ok(exec) = rx.recv().await {
-            debug!("[실시간] 통합 체결 수신: {:?}", exec);
+            trace!("[실시간] 통합 체결 수신: {:?}", exec);
             i += 1;
             if i == 10 {
                 break;

--- a/src/stock/data.rs
+++ b/src/stock/data.rs
@@ -318,7 +318,7 @@ impl KoreaStockData {
         let result = recv_subscribe_response(tr_id.clone(), &mut read, &mut write).await?;
 
         if let Some(handle) = self.handles.remove(&(String::default(), tr_id)) {
-            warn!("Aborting old handle");
+            debug!("Aborting old handle");
             handle.abort();
         }
 
@@ -421,7 +421,7 @@ fn parse_subscribe_response(
                             let tr_id = match TrId::from_str(&result_tr.to_string()) {
                                 Ok(tr_id) => tr_id,
                                 Err(e) => {
-                                    error!("Failed to parse tr_id: {}", e);
+                                    warn!("Failed to parse tr_id: {}", e);
                                     return Ok(None);
                                 }
                             };
@@ -580,7 +580,7 @@ where
                     msg = read.next() => {
                         match msg {
                             Some(Ok(Message::Text(s))) => {
-                                debug!("Get message from stream={:?}", s);
+                                trace!("Get message from stream={:?}", s);
                                 if let Ok(j) = json::parse(&s) {
                                     match parse_subscribe_response(&j) {
                                         Ok(Some(result)) => {
@@ -592,7 +592,7 @@ where
                                                     DataStreamCmdMessage::Unsubscribe(result.tr_key().clone(), result.tr_id().clone())
                                                 }
                                                 msg => {
-                                                    error!("Failed to parse subscribe response: msg={}", msg);
+                                                    warn!("Failed to parse subscribe response: msg={}", msg);
                                                     continue;
                                                 }
                                             };
@@ -601,7 +601,7 @@ where
                                                     error!("Failed to send result: {:?}", e);
                                                 }
                                             } else {
-                                                error!("Failed to send result");
+                                                warn!("Failed to send result: no pending request for key");
                                             }
                                         }
                                         Ok(None) => {
@@ -643,6 +643,7 @@ where
                         let result_tx = cmd.1;
                         match msg {
                             DataStreamCmdMessage::Subscribe(tr_key, tr_id) => {
+                                debug!("Subscribing: tr_key={}, tr_id={:?}", tr_key, tr_id);
                                 let msg_str = SubscribeRequest::new(
                                     app_key.clone(),
                                     app_secret.clone(),
@@ -659,6 +660,7 @@ where
                                 crate::update_last_call();
                             }
                             DataStreamCmdMessage::Unsubscribe(tr_key, tr_id) => {
+                                debug!("Unsubscribing: tr_key={}, tr_id={:?}", tr_key, tr_id);
                                 let msg_str = SubscribeRequest::new(
                                     app_key.clone(),
                                     app_secret.clone(),

--- a/src/types/stream/stock/exec.rs
+++ b/src/types/stream/stock/exec.rs
@@ -129,7 +129,7 @@ impl StreamParser<Body> for Exec {
                     }
                     bodies
                 } else {
-                    error!("Invalid data: {}", s);
+                    warn!("invalid data: {}", s);
                     Vec::new()
                 }
             };

--- a/src/types/stream/stock/ordb.rs
+++ b/src/types/stream/stock/ordb.rs
@@ -161,7 +161,7 @@ impl StreamParser<Body> for Ordb {
                     }
                     bodies
                 } else {
-                    error!("invalid data: {}", s);
+                    warn!("invalid data: {}", s);
                     Vec::new()
                 }
             };


### PR DESCRIPTION
## 변경 사항

data stream 및 stream types 전체 로그 레벨 정리.

### data.rs

| 위치 | 변경 전 | 변경 후 | 이유 |
|------|---------|---------|------|
| 스트림 메시지 수신 | `debug!` | `trace!` | 매 틱마다 찍히는 데이터 흐름 |
| 기존 핸들 abort | `warn!` | `debug!` | 재구독 시 정상 흐름 |
| tr_id 파싱 실패 | `error!` | `warn!` | `Ok(None)` 반환 후 계속 진행 |
| 알 수 없는 subscribe msg | `error!` | `warn!` | `continue`로 루프 유지 |
| result_tx 없음 | `error!` | `warn!` | 타이밍 이슈 가능, 치명적 아님 |
| Subscribe 커맨드 처리 | (없음) | `debug!` 추가 | 의사결정 지점 |
| Unsubscribe 커맨드 처리 | (없음) | `debug!` 추가 | 의사결정 지점 |

### ordb.rs / exec.rs

| 위치 | 변경 전 | 변경 후 | 이유 |
|------|---------|---------|------|
| 파이프 데이터 파싱 실패 | `error!` | `warn!` | 빈 body로 `Ok(...)` 반환, 스트림 유지됨 |
| 대소문자 불일치 | `"Invalid data"` | `"invalid data"` | exec/ordb 간 메시지 통일 |

### example.rs

| 위치 | 변경 전 | 변경 후 | 이유 |
|------|---------|---------|------|
| 실시간 틱 수신 ×6 | `debug!` | `trace!` | 매 틱마다 찍히는 데이터 흐름 |