### PR TITLE
불필요 디펜던시 줄이기

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,9 +2510,9 @@ dependencies = [
 
 [[package]]
 name = "xan-log"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1387f522dc13a7d74c849fb4ed9f565eb8f1c250ceb8016e7a736575a1704d"
+checksum = "1d961335ca227d5cc6a0c316ae75230be3de21e0bde0cbe832849441ca61fa98"
 dependencies = [
  "chrono",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,6 @@ tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread"] }
 tokio-tungstenite = "0.23"
 toml = { version = "0.8.8" }
 url = "2.4.1"
-xan-log = { version = "1.2.0", optional = true }
+xan-log = { version = "1.3.0", optional = true }
 xan-actor = "9.0.1"
 async-trait = "0.1.89"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["api", "client", "korea-investment", "stock", "trading"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-example = ["structopt"]
+example = ["structopt", "xan-log"]
 
 [[bin]]
 name = "example"
@@ -39,6 +39,6 @@ tokio = { version = "1.23.0", features = ["macros", "net", "rt-multi-thread"] }
 tokio-tungstenite = "0.23"
 toml = { version = "0.8.8" }
 url = "2.4.1"
-xan-log = "1.2.0"
+xan-log = { version = "1.2.0", optional = true }
 xan-actor = "9.0.1"
 async-trait = "0.1.89"


### PR DESCRIPTION
xan-log 디펜던시가 lib에도 포함되어 충돌이 일어나는 현상을 확인했습니다. 이 부분 제거했습니다.
이외, cargo update도 수행했습니다.